### PR TITLE
perf(bench): add a divan benchmark harness for EM, barcode correction and collate I/O

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,8 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Check benchmark targets
+      run: cargo check --benches --verbose
 
   Linting:
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "crossbeam-queue",
  "csv",
  "dashmap",
+ "divan",
  "flate2",
  "indicatif",
  "itertools",
@@ -548,6 +549,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
+
+[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +709,31 @@ name = "derive-new"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "divan"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a405457ec78b8fe08b0e32b4a3570ab5dff6dd16eb9e76a5ee0a9d9cbd898933"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2508,6 +2540,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ authors = [
 name = "alevin-fry"
 version = "0.17.1"
 edition = "2024"
+# divan supplies its own harness; `benches/common/` is a shared module rather
+# than a target, so autodiscovery is off and every bench is listed explicitly.
+autobenches = false
 
 description = "A suite of tools for the rapid, accurate and memory-frugal processing single-cell and single-nucleus sequencing data."
 license-file = "LICENSE"
@@ -91,10 +94,23 @@ dashmap = { version = "6.1.0", features = ["serde", "inline"] }
 rand_distr = "0.6"
 
 [dev-dependencies]
+divan = "0.1.21"
 tempfile = "3"
 slog-term = "2.9.2"
 polars = { version = "0.45.1", features = ["polars-io", "dtype-categorical"] }
 polars-io = { version = "0.45.1", features = ["csv"] }
+
+[[bench]]
+name = "em"
+harness = false
+
+[[bench]]
+name = "barcode"
+harness = false
+
+[[bench]]
+name = "collate_io"
+harness = false
 
 [profile.release]
 #debug = true

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,74 @@
+# Benchmarks
+
+Three [divan](https://docs.rs/divan) benchmark targets covering the routines a
+dependency or algorithm change is most likely to move:
+
+| target       | covers                                                                                  |
+|--------------|-----------------------------------------------------------------------------------------|
+| `em`         | `em_optimize_subset` (the per-cell EM driver behind the `*-em` resolutions), and loading the dumped equivalence classes back into the flat CSR layout |
+| `barcode`    | `generate_permitlist_map`, `generate_whitelist_set`, `get_all_one_edit_neighbors`         |
+| `collate_io` | Snappy encode/decode of a temporary-bucket-sized buffer, and bincode round-trip of the barcode-correction map |
+
+```sh
+cargo bench                      # all three
+cargo bench --bench em           # one
+cargo bench --bench em -- batch  # filter by name
+```
+
+## Running on real data
+
+The benchmarks default to a deterministic synthetic generator so that
+`cargo bench` works in a fresh checkout, and they print a note on stderr when
+they do. Synthetic numbers are fine for comparing two branches against each
+other; they are not representative of real input, and should not be quoted as
+if they were.
+
+Point `AF_BENCH_DATA` at a directory holding real artifacts to switch every
+bench over:
+
+```text
+$AF_BENCH_DATA/
+  gene_eqclass.txt.gz   # quant -r cr-like-em --dump-eqclasses
+  geqc_counts.mtx       # ditto
+  permit_list.txt       # one barcode per line, e.g. 10x_v3_permit.txt
+  map.collated.rad      # collate
+```
+
+Nothing is committed to the repository: the smallest useful fixture set is
+around 1.2 GB. The set above is what the project's own CI toy dataset produces:
+
+```sh
+wget https://umd.box.com/shared/static/uctm7oh0f2ef32aa3dmvk6zvbb8764up -O toy_data.tar.gz
+tar xzf toy_data.tar.gz
+fry=target/release/alevin-fry
+$fry generate-permit-list -u toy_data/10x_v3_permit.txt -d fw -i toy_data/alevin_map -o gpl
+$fry collate -i gpl -r toy_data/alevin_map -t 8
+$fry quant -r cr-like-em --small-thresh 0 --dump-eqclasses --use-mtx \
+     -m toy_data/t2g_3col.tsv -i gpl -o quant -t 8
+
+mkdir fixtures && cd fixtures
+ln -s ../quant/alevin/gene_eqclass.txt.gz ../quant/alevin/geqc_counts.mtx .
+ln -s ../gpl/map.collated.rad .
+ln -s ../toy_data/10x_v3_permit.txt permit_list.txt
+```
+
+## Comparing two branches
+
+divan reports a distribution per branch but does not pair samples across
+builds, so a difference is only believable when it is larger than the spread of
+the baseline. The protocol used for the performance changes in this repository:
+
+```sh
+export AF_BENCH_DATA=/path/to/fixtures
+git checkout master && cargo bench --bench em 2>&1 | tee /tmp/before.txt
+git checkout my-branch && cargo bench --bench em 2>&1 | tee /tmp/after.txt
+```
+
+Compare the **median** columns, not the fastest, and re-run both sides on an
+otherwise idle machine. Deltas under roughly 3% on these targets are inside the
+run-to-run noise observed on an M-series laptop and should not be reported as
+wins.
+
+A microbenchmark delta is also not a pipeline delta: `collate` is I/O bound and
+`quant` is threaded, so any claim about end-to-end time has to come from timing
+the actual subcommands on a real dataset.

--- a/benches/README.md
+++ b/benches/README.md
@@ -31,6 +31,7 @@ $AF_BENCH_DATA/
   gene_eqclass.txt.gz   # quant -r cr-like-em --dump-eqclasses
   geqc_counts.mtx       # ditto
   permit_list.txt       # one barcode per line, e.g. 10x_v3_permit.txt
+  permit_map.bin        # generate-permit-list output
   map.collated.rad      # collate
 ```
 
@@ -49,6 +50,7 @@ $fry quant -r cr-like-em --small-thresh 0 --dump-eqclasses --use-mtx \
 mkdir fixtures && cd fixtures
 ln -s ../quant/alevin/gene_eqclass.txt.gz ../quant/alevin/geqc_counts.mtx .
 ln -s ../gpl/map.collated.rad .
+ln -s ../gpl/permit_map.bin .
 ln -s ../toy_data/10x_v3_permit.txt permit_list.txt
 ```
 
@@ -60,8 +62,8 @@ the baseline. The protocol used for the performance changes in this repository:
 
 ```sh
 export AF_BENCH_DATA=/path/to/fixtures
-git checkout master && cargo bench --bench em 2>&1 | tee /tmp/before.txt
-git checkout my-branch && cargo bench --bench em 2>&1 | tee /tmp/after.txt
+git checkout master && cargo bench --bench em 2>&1 | tee "${TMPDIR:?}/before.txt"
+git checkout my-branch && cargo bench --bench em 2>&1 | tee "${TMPDIR:?}/after.txt"
 ```
 
 Compare the **median** columns, not the fastest, and re-run both sides on an

--- a/benches/barcode.rs
+++ b/benches/barcode.rs
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020-2026 COMBINE-lab.
+ *
+ * This file is part of alevin-fry
+ * (see https://www.github.com/COMBINE-lab/alevin-fry).
+ *
+ * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
+ */
+
+//! Barcode-correction benchmarks.
+//!
+//! `generate_permitlist_map` builds the map from every one-edit neighbour of a
+//! retained barcode back to that barcode; it is the correction step of the
+//! filtered `generate-permit-list` path and is almost entirely hash-table work
+//! (roughly 10 insertions per retained barcode). `get_all_one_edit_neighbors`
+//! is the pure bit-twiddling underneath it, with no hashing beyond the small
+//! scratch set, which separates the two costs.
+//!
+//! Run with real data:
+//! ```text
+//! AF_BENCH_DATA=/path/to/fixtures cargo bench --bench barcode
+//! ```
+
+mod common;
+
+use alevin_fry::utils::{
+    generate_permitlist_map, generate_whitelist_set, get_all_one_edit_neighbors,
+};
+
+const BC_LEN: usize = 16; // 10x v3 cell barcode
+
+fn main() {
+    divan::main();
+}
+
+fn barcodes(n: usize) -> Vec<u64> {
+    match common::fixture("permit_list.txt") {
+        Some(p) => common::load_barcodes(&p, n),
+        None => {
+            common::note_synthetic("barcode");
+            common::synthetic_barcodes(n, BC_LEN, 0xB0_1CE5)
+        }
+    }
+}
+
+/// Build the full one-edit correction map. This is the routine
+/// `process_filtered` calls once per run over the retained barcodes.
+#[divan::bench(args = [1_000, 10_000])]
+fn permitlist_map(bencher: divan::Bencher, n: usize) {
+    let bcs = barcodes(n);
+    bencher.bench_local(|| generate_permitlist_map(&bcs, BC_LEN).unwrap());
+}
+
+/// The set-valued variant, which drops the correction target and keeps only
+/// membership.
+#[divan::bench(args = [10_000])]
+fn whitelist_set(bencher: divan::Bencher, n: usize) {
+    let bcs = barcodes(n);
+    bencher.bench_local(|| generate_whitelist_set(&bcs, BC_LEN).unwrap());
+}
+
+/// Neighbour enumeration for a single barcode, reusing the scratch set exactly
+/// as the callers do.
+#[divan::bench]
+fn one_edit_neighbors(bencher: divan::Bencher) {
+    let bcs = barcodes(1_000);
+    // left to inference so the bench keeps compiling whichever `BuildHasher`
+    // `get_all_one_edit_neighbors` is declared with.
+    let mut neighbors = Default::default();
+    get_all_one_edit_neighbors(bcs[0], BC_LEN, &mut neighbors).unwrap();
+    neighbors.reserve(3 * BC_LEN + 8 * (BC_LEN - 1));
+    let mut i = 0usize;
+    bencher.bench_local(|| {
+        let bc = bcs[i % bcs.len()];
+        i += 1;
+        get_all_one_edit_neighbors(bc, BC_LEN, &mut neighbors).unwrap();
+        neighbors.len()
+    });
+}

--- a/benches/barcode.rs
+++ b/benches/barcode.rs
@@ -35,7 +35,7 @@ fn main() {
 
 fn barcodes(n: usize) -> Vec<u64> {
     match common::fixture("permit_list.txt") {
-        Some(p) => common::load_barcodes(&p, n),
+        Some(p) => common::load_barcodes(&p, n, BC_LEN),
         None => {
             common::note_synthetic("barcode");
             common::synthetic_barcodes(n, BC_LEN, 0xB0_1CE5)

--- a/benches/collate_io.rs
+++ b/benches/collate_io.rs
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2020-2026 COMBINE-lab.
+ *
+ * This file is part of alevin-fry
+ * (see https://www.github.com/COMBINE-lab/alevin-fry).
+ *
+ * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
+ */
+
+//! Benchmarks for the two CPU costs `collate` pays on top of its I/O.
+//!
+//! `collate` writes each temporary bucket through a Snappy frame encoder and
+//! reads it back the same way, and it deserializes the barcode-correction map
+//! produced by `generate-permit-list` before it can start. Neither is the
+//! dominant cost of the stage -- collate is I/O bound -- but both are the parts
+//! a dependency swap would move, so they are what a dependency benchmark must
+//! measure. The wall-clock effect on the stage as a whole has to be read off a
+//! full pipeline run, not off these numbers.
+//!
+//! Run with real data:
+//! ```text
+//! AF_BENCH_DATA=/path/to/fixtures cargo bench --bench collate_io
+//! ```
+
+mod common;
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+
+/// Size of one temporary-bucket write in `collate`. The buckets are sized from
+/// the input chunk offsets; a few MiB is the common case on 10x data.
+const CHUNK_SIZE: usize = 4 << 20;
+
+fn main() {
+    divan::main();
+}
+
+/// A buffer of collated-RAD bytes: real record bytes when a collated RAD file
+/// is available, otherwise a synthetic stand-in with a similar entropy profile
+/// (dense u32 reference ids, small counts, packed barcodes).
+fn chunk_bytes() -> Vec<u8> {
+    if let Some(p) = common::fixture("map.collated.rad") {
+        let mut f = std::fs::File::open(p).expect("could not open collated rad");
+        // skip the header; the tail of the file is pure record payload, which
+        // is what the bucket writer actually compresses.
+        let len = f.metadata().unwrap().len();
+        let skip = (len / 2).min(len.saturating_sub(CHUNK_SIZE as u64));
+        use std::io::Seek;
+        f.seek(std::io::SeekFrom::Start(skip)).unwrap();
+        let mut buf = vec![0u8; CHUNK_SIZE];
+        let mut read = 0usize;
+        while read < CHUNK_SIZE {
+            match f.read(&mut buf[read..]) {
+                Ok(0) => break,
+                Ok(n) => read += n,
+                Err(e) => panic!("could not read collated rad: {e}"),
+            }
+        }
+        buf.truncate(read);
+        return buf;
+    }
+
+    common::note_synthetic("collate_io");
+    let mut rng = common::Rng::new(0xC0_11A7E);
+    let mut buf = Vec::with_capacity(CHUNK_SIZE);
+    while buf.len() < CHUNK_SIZE {
+        buf.extend_from_slice(&(rng.below(375_446) as u32).to_le_bytes());
+        buf.extend_from_slice(&(1u32 + rng.below(4) as u32).to_le_bytes());
+        buf.extend_from_slice(&rng.next_u64().to_le_bytes());
+    }
+    buf.truncate(CHUNK_SIZE);
+    buf
+}
+
+fn snap_compress(src: &[u8]) -> Vec<u8> {
+    let mut enc = snap::write::FrameEncoder::new(Vec::with_capacity(src.len()));
+    enc.write_all(src).unwrap();
+    enc.into_inner().unwrap()
+}
+
+#[divan::bench]
+fn snap_encode(bencher: divan::Bencher) {
+    let src = chunk_bytes();
+    bencher
+        .counter(divan::counter::BytesCount::of_slice(&src))
+        .bench_local(|| snap_compress(&src));
+}
+
+#[divan::bench]
+fn snap_decode(bencher: divan::Bencher) {
+    let src = chunk_bytes();
+    let comp = snap_compress(&src);
+    bencher
+        .counter(divan::counter::BytesCount::of_slice(&src))
+        .bench_local(|| {
+            let mut out = Vec::with_capacity(src.len());
+            snap::read::FrameDecoder::new(&comp[..])
+                .read_to_end(&mut out)
+                .unwrap();
+            out
+        });
+}
+
+/// Compression ratio, reported once so that a throughput win can be weighed
+/// against the extra bytes it writes.
+#[divan::bench]
+fn snap_ratio(bencher: divan::Bencher) {
+    let src = chunk_bytes();
+    let comp = snap_compress(&src);
+    eprintln!(
+        "snappy: {} -> {} bytes ({:.3}x)",
+        src.len(),
+        comp.len(),
+        src.len() as f64 / comp.len() as f64
+    );
+    bencher.bench_local(|| comp.len());
+}
+
+/// The barcode-correction map, at the size the toy dataset produces
+/// (~80k entries). `collate` deserializes one of these per invocation, and
+/// every worker thread clones the `Arc` to it.
+fn correction_map(n: usize) -> HashMap<u64, u64> {
+    let bcs = common::synthetic_barcodes(n, 16, 0x5EED_5EED);
+    bcs.iter().map(|b| (*b, b ^ 0x3)).collect()
+}
+
+#[divan::bench(args = [80_000])]
+fn bincode_serialize_correction_map(bencher: divan::Bencher, n: usize) {
+    let m = correction_map(n);
+    bencher.bench_local(|| bincode::serialize(&m).unwrap());
+}
+
+#[divan::bench(args = [80_000])]
+fn bincode_deserialize_correction_map(bencher: divan::Bencher, n: usize) {
+    let m = correction_map(n);
+    let bytes = bincode::serialize(&m).unwrap();
+    bencher
+        .counter(divan::counter::BytesCount::of_slice(&bytes))
+        .bench_local(|| bincode::deserialize::<HashMap<u64, u64>>(&bytes).unwrap());
+}

--- a/benches/collate_io.rs
+++ b/benches/collate_io.rs
@@ -81,6 +81,13 @@ fn snap_compress(src: &[u8]) -> Vec<u8> {
 #[divan::bench]
 fn snap_encode(bencher: divan::Bencher) {
     let src = chunk_bytes();
+    let compressed_len = snap_compress(&src).len();
+    eprintln!(
+        "snappy: {} -> {} bytes ({:.3}x)",
+        src.len(),
+        compressed_len,
+        src.len() as f64 / compressed_len as f64
+    );
     bencher
         .counter(divan::counter::BytesCount::of_slice(&src))
         .bench_local(|| snap_compress(&src));
@@ -101,25 +108,26 @@ fn snap_decode(bencher: divan::Bencher) {
         });
 }
 
-/// Compression ratio, reported once so that a throughput win can be weighed
-/// against the extra bytes it writes.
-#[divan::bench]
-fn snap_ratio(bencher: divan::Bencher) {
-    let src = chunk_bytes();
-    let comp = snap_compress(&src);
-    eprintln!(
-        "snappy: {} -> {} bytes ({:.3}x)",
-        src.len(),
-        comp.len(),
-        src.len() as f64 / comp.len() as f64
-    );
-    bencher.bench_local(|| comp.len());
-}
-
 /// The barcode-correction map, at the size the toy dataset produces
 /// (~80k entries). `collate` deserializes one of these per invocation, and
 /// every worker thread clones the `Arc` to it.
 fn correction_map(n: usize) -> HashMap<u64, u64> {
+    if let Some(path) = common::fixture("permit_map.bin") {
+        let bytes = std::fs::read(path).expect("could not read permit_map.bin");
+        let map: HashMap<u64, u64> =
+            bincode::deserialize(&bytes).expect("could not deserialize permit_map.bin");
+        let mut entries: Vec<_> = map.into_iter().collect();
+        entries.sort_unstable_by_key(|(barcode, _)| *barcode);
+        entries.truncate(n);
+        assert_eq!(
+            entries.len(),
+            n,
+            "permit_map.bin contains fewer than {n} corrections"
+        );
+        return entries.into_iter().collect();
+    }
+
+    common::note_synthetic("collate_io::correction_map");
     let bcs = common::synthetic_barcodes(n, 16, 0x5EED_5EED);
     bcs.iter().map(|b| (*b, b ^ 0x3)).collect()
 }

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -18,6 +18,7 @@
 //!   gene_eqclass.txt.gz   # from `quant -r cr-like-em --dump-eqclasses`
 //!   geqc_counts.mtx       # ditto
 //!   permit_list.txt       # a barcode-per-line whitelist (e.g. 10x_v3_permit.txt)
+//!   permit_map.bin        # from `generate-permit-list`
 //!   map.collated.rad      # from `collate`
 //! ```
 //!
@@ -111,9 +112,9 @@ pub fn load_cell_data(path: &Path, max_cells: usize) -> Vec<CellData> {
 
 /// Build a synthetic `IndexedEqList` plus matching per-cell workloads.
 ///
-/// The shape is taken from the distribution observed on the project's own toy
-/// dataset (26k cells / 4.3M nonzeros): most equivalence classes carry a single
-/// gene label, a long tail carries 2-8, and a handful carry up to 64.
+/// This is a deterministic stress workload, not a model of any specific real
+/// dataset: most equivalence classes carry a single gene label, a long tail
+/// carries 2-8, and a handful carry up to 64.
 pub fn synthetic_workload(
     num_genes: usize,
     num_eqc: usize,
@@ -172,7 +173,7 @@ pub fn synthetic_barcodes(n: usize, bc_len: usize, seed: u64) -> Vec<u64> {
 }
 
 /// Read a barcode-per-line whitelist and 2-bit pack it, keeping the first `n`.
-pub fn load_barcodes(path: &Path, n: usize) -> Vec<u64> {
+pub fn load_barcodes(path: &Path, n: usize, bc_len: usize) -> Vec<u64> {
     use std::io::BufRead;
     let f = std::fs::File::open(path).expect("could not open permit list");
     let mut v = Vec::with_capacity(n);
@@ -182,8 +183,11 @@ pub fn load_barcodes(path: &Path, n: usize) -> Vec<u64> {
         if l.is_empty() {
             continue;
         }
+        if l.len() != bc_len {
+            continue;
+        }
         if let Some((_, km, _)) =
-            needletail::bitkmer::BitNuclKmer::new(l.as_bytes(), l.len() as u8, false).next()
+            needletail::bitkmer::BitNuclKmer::new(l.as_bytes(), bc_len as u8, false).next()
         {
             v.push(km.0);
         }
@@ -191,5 +195,10 @@ pub fn load_barcodes(path: &Path, n: usize) -> Vec<u64> {
             break;
         }
     }
+    assert_eq!(
+        v.len(),
+        n,
+        "permit_list.txt contains fewer than {n} valid {bc_len}-base barcodes"
+    );
     v
 }

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2020-2026 COMBINE-lab.
+ *
+ * This file is part of alevin-fry
+ * (see https://www.github.com/COMBINE-lab/alevin-fry).
+ *
+ * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
+ */
+
+//! Fixture loading shared by the benchmarks.
+//!
+//! The benchmarks prefer *real* data. Point `AF_BENCH_DATA` at a directory
+//! holding the artifacts of an actual run and every bench below switches from
+//! its synthetic fallback to the real thing:
+//!
+//! ```text
+//! $AF_BENCH_DATA/
+//!   gene_eqclass.txt.gz   # from `quant -r cr-like-em --dump-eqclasses`
+//!   geqc_counts.mtx       # ditto
+//!   permit_list.txt       # a barcode-per-line whitelist (e.g. 10x_v3_permit.txt)
+//!   map.collated.rad      # from `collate`
+//! ```
+//!
+//! No fixture is committed to the repository: the smallest useful ones are
+//! hundreds of megabytes. When a fixture is absent the bench falls back to a
+//! deterministic synthetic generator and says so on stderr, so that a number
+//! produced without real data is never mistaken for one produced with it.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+/// Root of the real-data fixtures, if the user provided one.
+pub fn data_dir() -> Option<PathBuf> {
+    let d = PathBuf::from(std::env::var_os("AF_BENCH_DATA")?);
+    if d.is_dir() { Some(d) } else { None }
+}
+
+/// Path of `name` under the fixture root, if both exist.
+pub fn fixture(name: &str) -> Option<PathBuf> {
+    let p = data_dir()?.join(name);
+    if p.is_file() { Some(p) } else { None }
+}
+
+/// Announce, once per bench binary, that we are running on synthetic input.
+pub fn note_synthetic(what: &str) {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        eprintln!(
+            "note: AF_BENCH_DATA is unset or incomplete; `{what}` runs on synthetic input. \
+             Numbers are comparable between branches but not representative of real data."
+        );
+    });
+}
+
+/// A logger that drops everything; the EM routines want one but the benchmarks
+/// do not want the I/O.
+pub fn null_logger() -> slog::Logger {
+    slog::Logger::root(slog::Discard, slog::o!())
+}
+
+/// xorshift64*: a tiny deterministic PRNG so the synthetic fallbacks are
+/// reproducible without pulling the `rand` seeding machinery into the benches.
+pub struct Rng(u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Rng(seed | 1)
+    }
+    pub fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    pub fn below(&mut self, n: u64) -> u64 {
+        self.next_u64() % n
+    }
+}
+
+/// Per-cell equivalence-class workload: `(eq_class_id, umi_count)` pairs, the
+/// exact shape `em_optimize_subset` consumes.
+pub type CellData = Vec<(u32, u32)>;
+
+/// Read `geqc_counts.mtx` (cells x eq-classes) into one `CellData` per cell,
+/// keeping the `max_cells` cells with the most equivalence classes. EM cost is
+/// dominated by the large cells, and taking the head of the file instead would
+/// make the bench a measure of whichever cells happened to be written first.
+pub fn load_cell_data(path: &Path, max_cells: usize) -> Vec<CellData> {
+    let tri: sprs::TriMatI<f32, u32> =
+        sprs::io::read_matrix_market(path).expect("could not read geqc_counts.mtx");
+    let csr = tri.to_csr::<usize>();
+
+    let mut cells: Vec<CellData> = csr
+        .outer_iterator()
+        .map(|row| {
+            row.iter()
+                .map(|(eqid, count)| (eqid as u32, *count as u32))
+                .collect()
+        })
+        .filter(|c: &CellData| !c.is_empty())
+        .collect();
+
+    cells.sort_unstable_by_key(|c| std::cmp::Reverse(c.len()));
+    cells.truncate(max_cells);
+    cells
+}
+
+/// Build a synthetic `IndexedEqList` plus matching per-cell workloads.
+///
+/// The shape is taken from the distribution observed on the project's own toy
+/// dataset (26k cells / 4.3M nonzeros): most equivalence classes carry a single
+/// gene label, a long tail carries 2-8, and a handful carry up to 64.
+pub fn synthetic_workload(
+    num_genes: usize,
+    num_eqc: usize,
+    num_cells: usize,
+    eqc_per_cell: usize,
+    seed: u64,
+) -> (alevin_fry::eq_class::IndexedEqList, Vec<CellData>) {
+    let mut rng = Rng::new(seed);
+    let mut eql = alevin_fry::eq_class::IndexedEqList::new();
+    eql.eq_label_starts.push(0);
+    eql.num_genes = num_genes;
+
+    let mut labels: Vec<u32> = Vec::with_capacity(64);
+    for _ in 0..num_eqc {
+        let r = rng.below(100);
+        let len = match r {
+            0..=64 => 1,
+            65..=94 => 2 + rng.below(7) as usize,
+            _ => 9 + rng.below(56) as usize,
+        };
+        labels.clear();
+        for _ in 0..len {
+            labels.push(rng.below(num_genes as u64) as u32);
+        }
+        labels.sort_unstable();
+        labels.dedup();
+        eql.add_label_vec(&labels);
+    }
+
+    let cells = (0..num_cells)
+        .map(|_| {
+            let mut c: CellData = (0..eqc_per_cell)
+                .map(|_| (rng.below(num_eqc as u64) as u32, 1 + rng.below(8) as u32))
+                .collect();
+            c.sort_unstable();
+            c.dedup_by_key(|(e, _)| *e);
+            c
+        })
+        .collect();
+
+    (eql, cells)
+}
+
+/// Synthetic 2-bit packed barcodes of length `bc_len`, deterministic in `seed`.
+pub fn synthetic_barcodes(n: usize, bc_len: usize, seed: u64) -> Vec<u64> {
+    let mut rng = Rng::new(seed);
+    let mask = if bc_len >= 32 {
+        u64::MAX
+    } else {
+        (1u64 << (2 * bc_len)) - 1
+    };
+    let mut v: Vec<u64> = (0..n).map(|_| rng.next_u64() & mask).collect();
+    v.sort_unstable();
+    v.dedup();
+    v
+}
+
+/// Read a barcode-per-line whitelist and 2-bit pack it, keeping the first `n`.
+pub fn load_barcodes(path: &Path, n: usize) -> Vec<u64> {
+    use std::io::BufRead;
+    let f = std::fs::File::open(path).expect("could not open permit list");
+    let mut v = Vec::with_capacity(n);
+    for line in std::io::BufReader::new(f).lines() {
+        let line = line.expect("could not read permit list");
+        let l = line.trim();
+        if l.is_empty() {
+            continue;
+        }
+        if let Some((_, km, _)) =
+            needletail::bitkmer::BitNuclKmer::new(l.as_bytes(), l.len() as u8, false).next()
+        {
+            v.push(km.0);
+        }
+        if v.len() == n {
+            break;
+        }
+    }
+    v
+}

--- a/benches/em.rs
+++ b/benches/em.rs
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2020-2026 COMBINE-lab.
+ *
+ * This file is part of alevin-fry
+ * (see https://www.github.com/COMBINE-lab/alevin-fry).
+ *
+ * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
+ */
+
+//! EM benchmarks.
+//!
+//! `em_optimize_subset` is the per-cell EM driver used by the `*-em` resolution
+//! strategies; it runs the M-step (`em_update_subset`) to convergence. On the
+//! project's toy dataset `quant -r cr-like-em --small-thresh 0` spends the bulk
+//! of its ~50 CPU-seconds inside it, so it is the single hottest routine in the
+//! quantification stage.
+//!
+//! Run with real data:
+//! ```text
+//! AF_BENCH_DATA=/path/to/fixtures cargo bench --bench em
+//! ```
+
+mod common;
+
+use alevin_fry::em::{EmInitType, em_optimize_subset};
+use alevin_fry::eq_class::IndexedEqList;
+use common::CellData;
+
+fn main() {
+    divan::main();
+}
+
+/// The eq-class list and the per-cell workloads, loaded once for the whole run.
+struct Workload {
+    eql: IndexedEqList,
+    cells: Vec<CellData>,
+    num_alphas: usize,
+}
+
+fn workload(max_cells: usize) -> Workload {
+    match (
+        common::fixture("gene_eqclass.txt.gz"),
+        common::fixture("geqc_counts.mtx"),
+    ) {
+        (Some(eqc), Some(counts)) => {
+            let eql = IndexedEqList::init_from_eqc_file(&eqc);
+            let cells = common::load_cell_data(&counts, max_cells);
+            let num_alphas = eql.num_genes;
+            Workload {
+                eql,
+                cells,
+                num_alphas,
+            }
+        }
+        _ => {
+            common::note_synthetic("em");
+            let (eql, cells) =
+                common::synthetic_workload(20_000, 40_000, max_cells, 400, 0xA1E7_1F2E);
+            let num_alphas = eql.num_genes;
+            Workload {
+                eql,
+                cells,
+                num_alphas,
+            }
+        }
+    }
+}
+
+/// Full EM to convergence over a batch of cells, single-threaded.
+///
+/// `quant` runs one of these per cell across a thread pool; benchmarking the
+/// batch serially removes the pool's scheduling noise while keeping the work
+/// identical.
+#[divan::bench(args = [16, 128])]
+fn em_optimize_subset_batch(bencher: divan::Bencher, num_cells: usize) {
+    let w = workload(num_cells);
+    let log = common::null_logger();
+    let cells = &w.cells[..w.cells.len().min(num_cells)];
+
+    bencher
+        .with_inputs(|| (vec![false; w.num_alphas], vec![true; w.num_alphas]))
+        .bench_local_values(|(mut unique_evidence, mut no_ambiguity)| {
+            let mut acc = 0.0f32;
+            for cell in cells {
+                let alphas = em_optimize_subset(
+                    &w.eql,
+                    cell,
+                    &mut unique_evidence,
+                    &mut no_ambiguity,
+                    EmInitType::Informative,
+                    w.num_alphas,
+                    false,
+                    None,
+                    &log,
+                );
+                acc += alphas.iter().sum::<f32>();
+            }
+            acc
+        });
+}
+
+/// The unique-counts-only path: no EM iteration, just the scatter that seeds
+/// `alphas_in`. Isolates the cost of walking the CSR label list from the cost
+/// of the iteration loop on top of it.
+#[divan::bench(args = [128])]
+fn em_unique_only(bencher: divan::Bencher, num_cells: usize) {
+    let w = workload(num_cells);
+    let log = common::null_logger();
+    let cells = &w.cells[..w.cells.len().min(num_cells)];
+
+    bencher
+        .with_inputs(|| (vec![false; w.num_alphas], vec![true; w.num_alphas]))
+        .bench_local_values(|(mut unique_evidence, mut no_ambiguity)| {
+            let mut acc = 0.0f32;
+            for cell in cells {
+                let alphas = em_optimize_subset(
+                    &w.eql,
+                    cell,
+                    &mut unique_evidence,
+                    &mut no_ambiguity,
+                    EmInitType::Informative,
+                    w.num_alphas,
+                    true,
+                    None,
+                    &log,
+                );
+                acc += alphas.iter().sum::<f32>();
+            }
+            acc
+        });
+}
+
+/// Loading the dumped equivalence classes back into the flat CSR layout.
+/// Only meaningful with real data; skipped otherwise.
+#[divan::bench]
+fn init_from_eqc_file(bencher: divan::Bencher) {
+    match common::fixture("gene_eqclass.txt.gz") {
+        Some(p) => {
+            bencher.bench_local(|| IndexedEqList::init_from_eqc_file(&p));
+        }
+        None => {
+            common::note_synthetic("em::init_from_eqc_file (skipped)");
+        }
+    }
+}

--- a/benches/em.rs
+++ b/benches/em.rs
@@ -80,7 +80,6 @@ fn em_optimize_subset_batch(bencher: divan::Bencher, num_cells: usize) {
     bencher
         .with_inputs(|| (vec![false; w.num_alphas], vec![true; w.num_alphas]))
         .bench_local_values(|(mut unique_evidence, mut no_ambiguity)| {
-            let mut acc = 0.0f32;
             for cell in cells {
                 let alphas = em_optimize_subset(
                     &w.eql,
@@ -93,9 +92,11 @@ fn em_optimize_subset_batch(bencher: divan::Bencher, num_cells: usize) {
                     None,
                     &log,
                 );
-                acc += alphas.iter().sum::<f32>();
+                // Consume the allocation without adding a dense alpha-vector
+                // scan to the timed work. That scan would specifically hide
+                // optimizations that make EM iteration sparse.
+                std::hint::black_box(alphas);
             }
-            acc
         });
 }
 
@@ -111,7 +112,6 @@ fn em_unique_only(bencher: divan::Bencher, num_cells: usize) {
     bencher
         .with_inputs(|| (vec![false; w.num_alphas], vec![true; w.num_alphas]))
         .bench_local_values(|(mut unique_evidence, mut no_ambiguity)| {
-            let mut acc = 0.0f32;
             for cell in cells {
                 let alphas = em_optimize_subset(
                     &w.eql,
@@ -124,9 +124,8 @@ fn em_unique_only(bencher: divan::Bencher, num_cells: usize) {
                     None,
                     &log,
                 );
-                acc += alphas.iter().sum::<f32>();
+                std::hint::black_box(alphas);
             }
-            acc
         });
 }
 


### PR DESCRIPTION
## Why

The repository has no `benches/`, so any dependency swap or hot-loop change has to be argued from third-party microbenchmarks rather than from this codebase. This PR adds the harness first, so that the changes that follow can be measured instead of asserted. It changes no library or binary code.

## What

Three [divan](https://docs.rs/divan) targets:

| target | covers |
|---|---|
| `em` | `em_optimize_subset` (per-cell EM driver behind the `*-em` resolutions) and `IndexedEqList::init_from_eqc_file` |
| `barcode` | `generate_permitlist_map`, `generate_whitelist_set`, `get_all_one_edit_neighbors` |
| `collate_io` | Snappy encode/decode of a temporary-bucket-sized buffer, bincode round trip of the barcode-correction map |

Benchmarks read real fixtures from `$AF_BENCH_DATA` when set, and fall back to a deterministic synthetic generator otherwise, printing a note on stderr when they do. No fixture is committed (the smallest useful set is ~1.2 GB); `benches/README.md` documents how to build it from the toy dataset CI already downloads.

`divan` was picked over `tango-bench` for the smaller footprint. divan does not pair samples across builds, so `benches/README.md` spells out the A/B protocol and the noise floor (~3% on these targets on an M-series laptop) rather than pretending the harness resolves smaller deltas than it does.

## Measurements

Real fixtures, produced from the CI toy dataset (29.5M reads, 26,126 cells, 375,446 refs, 78,899 genes). Apple M-series, 16 cores, macOS 26.6, `rustc 1.97.1`, release profile as configured in-tree.

`em` (128 cells with the most equivalence classes):

| bench | median |
|---|---|
| `em_optimize_subset_batch/16` | 339.3 ms |
| `em_optimize_subset_batch/128` | 2.427 s |
| `em_unique_only/128` | 20.64 ms |
| `init_from_eqc_file` | 49.58 ms |

`barcode`:

| bench | median |
|---|---|
| `permitlist_map/1000` | 4.917 ms |
| `permitlist_map/10000` | 51.54 ms |
| `whitelist_set/10000` | 53.22 ms |
| `one_edit_neighbors` | 1.978 µs |

`collate_io` (4 MiB of real collated-RAD payload):

| bench | median | throughput |
|---|---|---|
| `snap_encode` | 4.004 ms | 1.047 GB/s |
| `snap_decode` | 2.324 ms | 1.804 GB/s |
| `bincode_serialize_correction_map/80000` | 117.3 µs | |
| `bincode_deserialize_correction_map/80000` | 802.7 µs | 1.594 GB/s |

Snappy compresses that payload 1.882x.

## Two things the harness surfaced

Both are reported here as observations and are addressed separately, not in this PR:

1. **`em_optimize_subset` iterates densely over `num_alphas`.** The M-step itself is sparse (it walks only the equivalence classes present in the cell), but the convergence check and the `alphas_out` reset that follow each iteration run over all 78,899 genes regardless of how few the cell touches. Contrast `em_unique_only/128` (20.6 ms, no iteration) with `em_optimize_subset_batch/128` (2.43 s).

2. **Pipeline output is not byte-reproducible run to run, even from the same binary.** Three consecutive `generate-permit-list` + `collate` + `quant` runs on identical input produced different bytes for `quants_mat.mtx`, `quants_mat_rows.txt`, `permit_map.bin`, `permit_freq.bin` and `map.collated.rad`. The quantification itself is stable: re-keying every nonzero by its barcode gives a byte-identical digest across all three runs, so the difference is the order in which cells are emitted, not the counts. Worth knowing before reviewing any change that touches a hash table, since "the output changed" is the expected baseline behaviour here rather than evidence of a regression.

## Checks

- `cargo test --workspace`: 22 passed, 1 ignored, 0 failed
- `cargo clippy --workspace --all-targets`: clean
- `cargo fmt --check`: clean