### PR TITLE
fix: make the filtered permit list order-independent

### DIFF
--- a/src/cellfilter.rs
+++ b/src/cellfilter.rs
@@ -1417,10 +1417,18 @@ pub fn permit_list_from_threshold(
     hist: &HashMap<u64, u64, ahash::RandomState>,
     min_freq: u64,
 ) -> Vec<u64> {
-    let valid_bc: Vec<u64> = hist
+    let mut valid_bc: Vec<u64> = hist
         .iter()
         .filter_map(|(k, v)| if v >= &min_freq { Some(*k) } else { None })
         .collect();
+    // `hist` is a `HashMap` built by draining a `DashMap` that the parsing
+    // threads filled concurrently, so its iteration order depends on the order
+    // the threads happened to insert. That order used to reach the output:
+    // `generate_permitlist_map` gives an ambiguous one-edit neighbour to
+    // whichever permitted barcode claims it first, so two runs of the same
+    // binary on the same input corrected some barcodes differently. Sorting
+    // pins the winner to the lowest packed barcode.
+    valid_bc.sort_unstable();
     valid_bc
 }
 

--- a/src/cellfilter.rs
+++ b/src/cellfilter.rs
@@ -1407,17 +1407,15 @@ fn build_sample_permit_map(
             // Generate 1-edit neighbors for ALL observed rotation barcodes
             let all_observed: Vec<u64> =
                 sample_info.rotation_to_canonical.keys().copied().collect();
-            let full_map = afutils::generate_unambiguous_permitlist_map(
+            let full_map = afutils::generate_unambiguous_correction_map(
                 &all_observed,
                 sample_info.barcode_len,
+                |observed| sample_info.rotation_to_canonical[&observed],
             )
             .map_err(|e| anyhow!("failed to generate sample permit map: {}", e))?;
-            for (raw, corrected) in &full_map {
+            for (raw, canonical) in &full_map {
                 if !permit_map.contains_key(raw) {
-                    // Map the 1-edit neighbor to the same canonical as its corrected barcode
-                    if let Some(&canon) = sample_info.rotation_to_canonical.get(corrected) {
-                        permit_map.insert(*raw, canon);
-                    }
+                    permit_map.insert(*raw, *canonical);
                 }
             }
             info!(
@@ -2518,5 +2516,19 @@ mod cell_barcode_correction_tests {
         assert_eq!(permit_map.get(&5), Some(&5));
         assert!(!permit_map.contains_key(&1));
         assert_eq!(sample_indices, HashMap::from([(0, 0), (5, 1)]));
+
+        let rotations_of_one_sample = SampleBarcodeInfo {
+            canonical_barcodes: vec![9],
+            rotation_to_canonical: HashMap::from([(0, 9), (5, 9)]),
+            canonical_to_name: HashMap::new(),
+            barcode_len: 2,
+        };
+        let (permit_map, _) = build_sample_permit_map(
+            &rotations_of_one_sample,
+            &SampleCorrectionMode::OneEdit,
+            &log,
+        )
+        .unwrap();
+        assert_eq!(permit_map.get(&1), Some(&9));
     }
 }

--- a/src/cellfilter.rs
+++ b/src/cellfilter.rs
@@ -17,7 +17,7 @@ use crate::utils as afutils;
 use crate::utils::KnownRecordType;
 #[allow(unused_imports)]
 use ahash::{AHasher, RandomState};
-use anyhow::{Context, anyhow};
+use anyhow::{Context, anyhow, bail};
 use bio_types::strand::Strand;
 use bstr::io::BufReadExt;
 use dashmap::DashMap;
@@ -539,13 +539,9 @@ fn process_filtered(
 
     // generate the map from each permitted barcode to all barcodes within
     // edit distance 1 of it.
-    let full_permit_list = afutils::generate_permitlist_map_with_policy(
-        &valid_bc,
-        barcode_len as usize,
-        &hm,
-        gpl_opts.cell_barcode_collision_policy,
-    )
-    .map_err(|error| anyhow!("failed to generate permit list map: {}", error))?;
+    let full_permit_list =
+        afutils::generate_unambiguous_permitlist_map(&valid_bc, barcode_len as usize)
+            .map_err(|error| anyhow!("failed to generate permit list map: {}", error))?;
 
     let s2 = ahash::RandomState::with_seeds(2u64, 7u64, 1u64, 8u64);
     let mut permitted_map = HashMap::with_capacity_and_hasher(valid_bc.len(), s2);
@@ -1090,13 +1086,9 @@ fn do_generate_permit_list_multi_bc(
                     sample_name
                 );
 
-                let full_permit_list = afutils::generate_permitlist_map_with_policy(
-                    &kept_bcs,
-                    cell_bc_len as usize,
-                    &cell_hist,
-                    gpl_opts.cell_barcode_collision_policy,
-                )
-                .map_err(|e| anyhow!("failed to generate permit list map: {}", e))?;
+                let full_permit_list =
+                    afutils::generate_unambiguous_permitlist_map(&kept_bcs, cell_bc_len as usize)
+                        .map_err(|e| anyhow!("failed to generate permit list map: {}", e))?;
                 let map_path = sample_dir.join("permit_map.bin");
                 let map_file = File::create(&map_path)?;
                 bincode::serialize_into(BufWriter::new(map_file), &full_permit_list)
@@ -1138,13 +1130,9 @@ fn do_generate_permit_list_multi_bc(
                     sample_name
                 );
 
-                let full_permit_list = afutils::generate_permitlist_map_with_policy(
-                    &kept_bcs,
-                    cell_bc_len as usize,
-                    &cell_hist,
-                    gpl_opts.cell_barcode_collision_policy,
-                )
-                .map_err(|e| anyhow!("failed to generate permit list map: {}", e))?;
+                let full_permit_list =
+                    afutils::generate_unambiguous_permitlist_map(&kept_bcs, cell_bc_len as usize)
+                        .map_err(|e| anyhow!("failed to generate permit list map: {}", e))?;
                 let map_path = sample_dir.join("permit_map.bin");
                 let map_file = File::create(&map_path)?;
                 bincode::serialize_into(BufWriter::new(map_file), &full_permit_list)
@@ -1225,6 +1213,8 @@ struct SampleBarcodeInfo {
     rotation_to_canonical: HashMap<u64, u64>,
     /// Maps canonical barcode to sample name.
     canonical_to_name: HashMap<u64, String>,
+    /// Number of nucleotides in each packed sample barcode.
+    barcode_len: usize,
 }
 
 /// Load sample barcodes from a file.
@@ -1257,6 +1247,7 @@ fn load_sample_barcode_list(
     let mut canonical_to_name: HashMap<u64, String> = HashMap::new();
     let mut canonical_order: Vec<u64> = Vec::new(); // preserves order, deduplicated
     let mut has_tsv_columns = false;
+    let mut barcode_len = None;
 
     for line in reader.lines() {
         let line = line?;
@@ -1278,6 +1269,29 @@ fn load_sample_barcode_list(
             // Single column: barcode only (each is its own sample)
             (parts[0], parts[0], parts[0].to_string())
         };
+
+        if observed_seq.len() != canonical_seq.len() {
+            bail!(
+                "sample barcode '{}' and its canonical barcode '{}' have different lengths",
+                observed_seq,
+                canonical_seq
+            );
+        }
+        if !(1..=32).contains(&observed_seq.len()) {
+            bail!(
+                "sample barcode length {} is unsupported; expected 1 through 32 bases",
+                observed_seq.len()
+            );
+        }
+        match barcode_len {
+            Some(expected) if expected != observed_seq.len() => bail!(
+                "sample barcode file mixes lengths {} and {}",
+                expected,
+                observed_seq.len()
+            ),
+            None => barcode_len = Some(observed_seq.len()),
+            _ => {}
+        }
 
         let rc = |seq: &str| -> String {
             seq.bytes()
@@ -1325,6 +1339,12 @@ fn load_sample_barcode_list(
 
     let num_rotations = rotation_to_canonical.len();
     let num_canonical = canonical_order.len();
+    let barcode_len = barcode_len.ok_or_else(|| {
+        anyhow!(
+            "sample barcode list {} contains no barcodes",
+            path.display()
+        )
+    })?;
 
     if has_tsv_columns && num_rotations > num_canonical {
         info!(
@@ -1347,6 +1367,7 @@ fn load_sample_barcode_list(
         canonical_barcodes: canonical_order,
         rotation_to_canonical,
         canonical_to_name,
+        barcode_len,
     })
 }
 
@@ -1386,15 +1407,11 @@ fn build_sample_permit_map(
             // Generate 1-edit neighbors for ALL observed rotation barcodes
             let all_observed: Vec<u64> =
                 sample_info.rotation_to_canonical.keys().copied().collect();
-            let bc_len = if !all_observed.is_empty() {
-                // Estimate barcode length from packed value
-                // For 8bp barcodes: 2*8 = 16 bits used
-                8usize // TODO: derive from actual barcode length
-            } else {
-                8usize
-            };
-            let full_map = afutils::generate_permitlist_map(&all_observed, bc_len)
-                .map_err(|e| anyhow!("failed to generate sample permit map: {}", e))?;
+            let full_map = afutils::generate_unambiguous_permitlist_map(
+                &all_observed,
+                sample_info.barcode_len,
+            )
+            .map_err(|e| anyhow!("failed to generate sample permit map: {}", e))?;
             for (raw, corrected) in &full_map {
                 if !permit_map.contains_key(raw) {
                     // Map the 1-edit neighbor to the same canonical as its corrected barcode
@@ -1576,19 +1593,9 @@ pub fn permit_list_from_threshold(
     hist: &HashMap<u64, u64, ahash::RandomState>,
     min_freq: u64,
 ) -> Vec<u64> {
-    let mut valid_bc: Vec<u64> = hist
-        .iter()
+    hist.iter()
         .filter_map(|(k, v)| if v >= &min_freq { Some(*k) } else { None })
-        .collect();
-    // `hist` is a `HashMap` built by draining a `DashMap` that the parsing
-    // threads filled concurrently, so its iteration order depends on the order
-    // the threads happened to insert. That order used to reach the output:
-    // `generate_permitlist_map` gives an ambiguous one-edit neighbour to
-    // whichever permitted barcode claims it first, so two runs of the same
-    // binary on the same input corrected some barcodes differently. Sorting
-    // pins the winner to the lowest packed barcode.
-    valid_bc.sort_unstable();
-    valid_bc
+        .collect()
 }
 
 pub fn permit_list_from_file<P>(ifile: P, bclen: u16) -> Vec<u64>
@@ -2493,5 +2500,23 @@ mod cell_barcode_correction_tests {
             serde_json::to_string(&CellBarcodeCorrectionStrategy::Frequency).unwrap(),
             "\"frequency\""
         );
+    }
+
+    #[test]
+    fn sample_one_edit_correction_drops_cross_sample_collisions() {
+        let sample_info = SampleBarcodeInfo {
+            canonical_barcodes: vec![0, 5],
+            rotation_to_canonical: HashMap::from([(0, 0), (5, 5)]),
+            canonical_to_name: HashMap::new(),
+            barcode_len: 2,
+        };
+        let log = slog::Logger::root(slog::Discard, slog::o!());
+        let (permit_map, sample_indices) =
+            build_sample_permit_map(&sample_info, &SampleCorrectionMode::OneEdit, &log).unwrap();
+
+        assert_eq!(permit_map.get(&0), Some(&0));
+        assert_eq!(permit_map.get(&5), Some(&5));
+        assert!(!permit_map.contains_key(&1));
+        assert_eq!(sample_indices, HashMap::from([(0, 0), (5, 1)]));
     }
 }

--- a/src/cellfilter.rs
+++ b/src/cellfilter.rs
@@ -405,8 +405,13 @@ fn process_filtered(
 
     // generate the map from each permitted barcode to all barcodes within
     // edit distance 1 of it.
-    let full_permit_list =
-        afutils::generate_permitlist_map(&valid_bc, barcode_len as usize).unwrap();
+    let full_permit_list = afutils::generate_permitlist_map_with_policy(
+        &valid_bc,
+        barcode_len as usize,
+        &hm,
+        gpl_opts.cell_barcode_collision_policy,
+    )
+    .map_err(|error| anyhow!("failed to generate permit list map: {}", error))?;
 
     let s2 = ahash::RandomState::with_seeds(2u64, 7u64, 1u64, 8u64);
     let mut permitted_map = HashMap::with_capacity_and_hasher(valid_bc.len(), s2);
@@ -941,9 +946,13 @@ fn do_generate_permit_list_multi_bc(
                     sample_name
                 );
 
-                let full_permit_list =
-                    afutils::generate_permitlist_map(&kept_bcs, cell_bc_len as usize)
-                        .map_err(|e| anyhow!("failed to generate permit list map: {}", e))?;
+                let full_permit_list = afutils::generate_permitlist_map_with_policy(
+                    &kept_bcs,
+                    cell_bc_len as usize,
+                    &cell_hist,
+                    gpl_opts.cell_barcode_collision_policy,
+                )
+                .map_err(|e| anyhow!("failed to generate permit list map: {}", e))?;
                 let map_path = sample_dir.join("permit_map.bin");
                 let map_file = File::create(&map_path)?;
                 bincode::serialize_into(BufWriter::new(map_file), &full_permit_list)
@@ -985,9 +994,13 @@ fn do_generate_permit_list_multi_bc(
                     sample_name
                 );
 
-                let full_permit_list =
-                    afutils::generate_permitlist_map(&kept_bcs, cell_bc_len as usize)
-                        .map_err(|e| anyhow!("failed to generate permit list map: {}", e))?;
+                let full_permit_list = afutils::generate_permitlist_map_with_policy(
+                    &kept_bcs,
+                    cell_bc_len as usize,
+                    &cell_hist,
+                    gpl_opts.cell_barcode_collision_policy,
+                )
+                .map_err(|e| anyhow!("failed to generate permit list map: {}", e))?;
                 let map_path = sample_dir.join("permit_map.bin");
                 let map_file = File::create(&map_path)?;
                 bincode::serialize_into(BufWriter::new(map_file), &full_permit_list)

--- a/src/prog_opts.rs
+++ b/src/prog_opts.rs
@@ -63,6 +63,24 @@ pub enum SampleBarcodeOri {
     Reverse,
 }
 
+/// Resolves a raw cell barcode that is one edit away from multiple retained
+/// cell barcodes in a filtered RNA permit list.
+///
+/// This policy does not affect exact matches, unfiltered RNA workflows, sample
+/// barcodes, or ATAC barcode correction.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
+pub enum BarcodeCollisionPolicy {
+    /// Do not correct a barcode when more than one retained barcode is a
+    /// one-edit neighbor. This is the conservative default.
+    #[default]
+    DropAmbiguous,
+    /// Correct to the retained neighbor with the largest observed count. Ties
+    /// are resolved by choosing the lowest packed-barcode value.
+    PreferMostFrequent,
+    /// Correct to the lowest packed-barcode neighbor.
+    AcceptFirstNeighbor,
+}
+
 #[derive(TypedBuilder, Debug, Serialize)]
 pub struct GenPermitListOpts<'a, 'b, 'c, 'd, 'e> {
     pub input_dir: &'a PathBuf,
@@ -75,6 +93,10 @@ pub struct GenPermitListOpts<'a, 'b, 'c, 'd, 'e> {
     pub version: &'d str,
     #[serde(skip_serializing)]
     pub log: &'e slog::Logger,
+    /// Policy for ambiguous one-edit cell-barcode corrections in filtered RNA
+    /// permit-list workflows. This is serialized into the run metadata.
+    #[builder(default)]
+    pub cell_barcode_collision_policy: BarcodeCollisionPolicy,
     /// Path to known sample barcode list (one per line). When present,
     /// triggers multi-barcode mode (e.g., 10x Flex).
     #[builder(default)]

--- a/src/prog_opts.rs
+++ b/src/prog_opts.rs
@@ -63,24 +63,6 @@ pub enum SampleBarcodeOri {
     Reverse,
 }
 
-/// Resolves a raw cell barcode that is one edit away from multiple retained
-/// cell barcodes in a filtered RNA permit list.
-///
-/// This policy does not affect exact matches, unfiltered RNA workflows, sample
-/// barcodes, or ATAC barcode correction.
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
-pub enum BarcodeCollisionPolicy {
-    /// Do not correct a barcode when more than one retained barcode is a
-    /// one-edit neighbor. This is the conservative default.
-    #[default]
-    DropAmbiguous,
-    /// Correct to the retained neighbor with the largest observed count. Ties
-    /// are resolved by choosing the lowest packed-barcode value.
-    PreferMostFrequent,
-    /// Correct to the lowest packed-barcode neighbor.
-    AcceptFirstNeighbor,
-}
-
 #[derive(TypedBuilder, Debug, Serialize)]
 pub struct GenPermitListOpts<'a, 'b, 'c, 'd, 'e> {
     pub input_dir: &'a PathBuf,
@@ -93,10 +75,6 @@ pub struct GenPermitListOpts<'a, 'b, 'c, 'd, 'e> {
     pub version: &'d str,
     #[serde(skip_serializing)]
     pub log: &'e slog::Logger,
-    /// Policy for ambiguous one-edit cell-barcode corrections in filtered RNA
-    /// permit-list workflows. This is serialized into the run metadata.
-    #[builder(default)]
-    pub cell_barcode_collision_policy: BarcodeCollisionPolicy,
     /// Path to known sample barcode list (one per line). When present,
     /// triggers multi-barcode mode (e.g., 10x Flex).
     #[builder(default)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1078,19 +1078,39 @@ pub(crate) fn generate_unambiguous_permitlist_map(
     permit_bcs: &[u64],
     bc_length: usize,
 ) -> Result<HashMap<u64, u64>, Box<dyn Error>> {
+    generate_unambiguous_correction_map(permit_bcs, bc_length, |barcode| barcode)
+}
+
+/// Build an order-independent correction map from permitted source barcodes to
+/// caller-defined targets.
+///
+/// Multiple source barcodes may intentionally share a target, as happens when
+/// Flex sample-barcode rotations identify the same canonical sample. A neighbor
+/// is ambiguous only when its candidate sources lead to different targets.
+pub(crate) fn generate_unambiguous_correction_map<F>(
+    permit_bcs: &[u64],
+    bc_length: usize,
+    target_for: F,
+) -> Result<HashMap<u64, u64>, Box<dyn Error>>
+where
+    F: Fn(u64) -> u64,
+{
     let mut correction_map = HashMap::with_capacity(10 * permit_bcs.len());
+    let mut exact_barcodes = HashSet::with_capacity(permit_bcs.len());
     for &bc in permit_bcs {
-        correction_map.insert(bc, bc);
+        exact_barcodes.insert(bc);
+        correction_map.insert(bc, target_for(bc));
     }
 
     let mut neighbors = HashSet::with_capacity(3 * bc_length + 8 * (bc_length - 1));
     let mut ambiguous = HashSet::new();
     for &bc in permit_bcs {
+        let target = target_for(bc);
         get_all_one_edit_neighbors(bc, bc_length, &mut neighbors)?;
         for &neighbor in &neighbors {
-            // An exact retained barcode always maps to itself, regardless of
-            // whether it is also a one-edit neighbor of another retained one.
-            if correction_map.get(&neighbor) == Some(&neighbor) {
+            // An exact permitted source always keeps its explicit target,
+            // regardless of neighboring permitted sources.
+            if exact_barcodes.contains(&neighbor) {
                 continue;
             }
 
@@ -1098,12 +1118,12 @@ pub(crate) fn generate_unambiguous_permitlist_map(
                 continue;
             }
             match correction_map.get(&neighbor).copied() {
-                Some(previous) if previous != bc => {
+                Some(previous) if previous != target => {
                     correction_map.remove(&neighbor);
                     ambiguous.insert(neighbor);
                 }
                 None => {
-                    correction_map.insert(neighbor, bc);
+                    correction_map.insert(neighbor, target);
                 }
                 _ => {}
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,6 +23,7 @@ use needletail::bitkmer::*;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fs::File;
+use std::hash::BuildHasher;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::Path;
 use std::path::PathBuf;
@@ -1050,6 +1051,78 @@ pub fn generate_permitlist_map(
     Ok(one_edit_barcode_map)
 }
 
+/// Builds the filtered RNA cell-barcode correction map using an explicit
+/// collision policy. The public [`generate_permitlist_map`] function retains
+/// its historical signature and behavior for other workflows and callers.
+pub(crate) fn generate_permitlist_map_with_policy<S>(
+    permit_bcs: &[u64],
+    bc_length: usize,
+    observed_counts: &HashMap<u64, u64, S>,
+    policy: crate::prog_opts::BarcodeCollisionPolicy,
+) -> Result<HashMap<u64, u64>, Box<dyn Error>>
+where
+    S: BuildHasher,
+{
+    use crate::prog_opts::BarcodeCollisionPolicy;
+
+    let mut ranked_bcs = permit_bcs.to_vec();
+    match policy {
+        BarcodeCollisionPolicy::PreferMostFrequent => ranked_bcs.sort_unstable_by(|a, b| {
+            observed_counts
+                .get(b)
+                .copied()
+                .unwrap_or_default()
+                .cmp(&observed_counts.get(a).copied().unwrap_or_default())
+                .then_with(|| a.cmp(b))
+        }),
+        BarcodeCollisionPolicy::DropAmbiguous | BarcodeCollisionPolicy::AcceptFirstNeighbor => {
+            ranked_bcs.sort_unstable()
+        }
+    }
+
+    let mut correction_map = HashMap::with_capacity(10 * ranked_bcs.len());
+    for &bc in &ranked_bcs {
+        correction_map.insert(bc, bc);
+    }
+
+    let mut neighbors = HashSet::with_capacity(3 * bc_length + 8 * (bc_length - 1));
+    let mut ambiguous = HashSet::new();
+    for &bc in &ranked_bcs {
+        get_all_one_edit_neighbors(bc, bc_length, &mut neighbors)?;
+        for &neighbor in &neighbors {
+            // An exact retained barcode always maps to itself, regardless of
+            // whether it is also a one-edit neighbor of another retained one.
+            if correction_map.get(&neighbor) == Some(&neighbor) {
+                continue;
+            }
+
+            match policy {
+                BarcodeCollisionPolicy::DropAmbiguous => {
+                    if ambiguous.contains(&neighbor) {
+                        continue;
+                    }
+                    match correction_map.get(&neighbor).copied() {
+                        Some(previous) if previous != bc => {
+                            correction_map.remove(&neighbor);
+                            ambiguous.insert(neighbor);
+                        }
+                        None => {
+                            correction_map.insert(neighbor, bc);
+                        }
+                        _ => {}
+                    }
+                }
+                BarcodeCollisionPolicy::PreferMostFrequent
+                | BarcodeCollisionPolicy::AcceptFirstNeighbor => {
+                    correction_map.entry(neighbor).or_insert(bc);
+                }
+            }
+        }
+    }
+
+    Ok(correction_map)
+}
+
 /// Reads the contents of the file `flist`, which should contain
 /// a single barcode per-line, and returns a Result that is either
 /// a HashSet containing the k-mer encoding of all barcodes or
@@ -1143,14 +1216,16 @@ impl FromStr for InternalVersionInfo {
 
 #[cfg(test)]
 mod tests {
+    use crate::prog_opts::BarcodeCollisionPolicy;
     use crate::utils::InternalVersionInfo;
     use crate::utils::ProbMap;
+    use crate::utils::generate_permitlist_map_with_policy;
     use crate::utils::generate_whitelist_set;
     use crate::utils::get_all_indels;
     use crate::utils::get_all_one_edit_neighbors;
     use crate::utils::get_all_snps;
     use crate::utils::get_bit_mask;
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::str::FromStr;
 
     #[test]
@@ -1225,6 +1300,89 @@ mod tests {
                 1, 3, 4, 5, 6, 9, 11, 12, 13, 14, 15, 23, 28, 29, 30, 31, 39, 55
             ]
         );
+    }
+
+    fn collision_map(
+        permit_bcs: &[u64],
+        counts: &[(u64, u64)],
+        policy: BarcodeCollisionPolicy,
+    ) -> HashMap<u64, u64> {
+        let counts: HashMap<_, _> = counts.iter().copied().collect();
+        generate_permitlist_map_with_policy(permit_bcs, 2, &counts, policy).unwrap()
+    }
+
+    #[test]
+    fn barcode_collision_policy_preserves_exact_and_unique_matches() {
+        let map = collision_map(
+            &[0, 5],
+            &[(0, 10), (5, 20)],
+            BarcodeCollisionPolicy::DropAmbiguous,
+        );
+        assert_eq!(map.get(&0), Some(&0));
+        assert_eq!(map.get(&5), Some(&5));
+        assert_eq!(map.get(&2), Some(&0));
+    }
+
+    #[test]
+    fn barcode_collision_policy_drops_ambiguous_neighbors_by_default() {
+        assert_eq!(
+            BarcodeCollisionPolicy::default(),
+            BarcodeCollisionPolicy::DropAmbiguous
+        );
+        let forward = collision_map(
+            &[0, 5],
+            &[(0, 10), (5, 20)],
+            BarcodeCollisionPolicy::DropAmbiguous,
+        );
+        let reverse = collision_map(
+            &[5, 0],
+            &[(0, 10), (5, 20)],
+            BarcodeCollisionPolicy::DropAmbiguous,
+        );
+        assert!(!forward.contains_key(&1));
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn barcode_collision_policy_prefers_frequency_then_packed_value() {
+        let frequent = collision_map(
+            &[0, 5],
+            &[(0, 10), (5, 20)],
+            BarcodeCollisionPolicy::PreferMostFrequent,
+        );
+        assert_eq!(frequent.get(&1), Some(&5));
+
+        let tied = collision_map(
+            &[5, 0],
+            &[(0, 20), (5, 20)],
+            BarcodeCollisionPolicy::PreferMostFrequent,
+        );
+        assert_eq!(tied.get(&1), Some(&0));
+    }
+
+    #[test]
+    fn barcode_collision_policy_accept_first_is_sorted_and_repeatable() {
+        let expected = collision_map(
+            &[5, 0],
+            &[(0, 10), (5, 20)],
+            BarcodeCollisionPolicy::AcceptFirstNeighbor,
+        );
+        assert_eq!(expected.get(&1), Some(&0));
+
+        std::thread::scope(|scope| {
+            for iteration in 0..32 {
+                let expected = &expected;
+                scope.spawn(move || {
+                    let input = if iteration % 2 == 0 { [0, 5] } else { [5, 0] };
+                    let actual = collision_map(
+                        &input,
+                        &[(0, 10), (5, 20)],
+                        BarcodeCollisionPolicy::AcceptFirstNeighbor,
+                    );
+                    assert_eq!(&actual, expected);
+                });
+            }
+        });
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,7 +23,6 @@ use needletail::bitkmer::*;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fs::File;
-use std::hash::BuildHasher;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::Path;
 use std::path::PathBuf;
@@ -1068,43 +1067,25 @@ pub fn generate_permitlist_map(
     Ok(one_edit_barcode_map)
 }
 
-/// Builds the filtered RNA cell-barcode correction map using an explicit
-/// collision policy. The public [`generate_permitlist_map`] function retains
-/// its historical signature and behavior for other workflows and callers.
-pub(crate) fn generate_permitlist_map_with_policy<S>(
+/// Builds a one-edit correction map that retains only unambiguous corrections.
+///
+/// Exact permitted barcodes always map to themselves. A non-exact barcode is
+/// omitted when it is a one-edit neighbor of more than one permitted barcode.
+/// Unlike [`generate_permitlist_map`], the result is therefore independent of
+/// the order of `permit_bcs`. The historical public function remains unchanged
+/// for downstream callers that rely on its permissive behavior.
+pub(crate) fn generate_unambiguous_permitlist_map(
     permit_bcs: &[u64],
     bc_length: usize,
-    observed_counts: &HashMap<u64, u64, S>,
-    policy: crate::prog_opts::BarcodeCollisionPolicy,
-) -> Result<HashMap<u64, u64>, Box<dyn Error>>
-where
-    S: BuildHasher,
-{
-    use crate::prog_opts::BarcodeCollisionPolicy;
-
-    let mut ranked_bcs = permit_bcs.to_vec();
-    match policy {
-        BarcodeCollisionPolicy::PreferMostFrequent => ranked_bcs.sort_unstable_by(|a, b| {
-            observed_counts
-                .get(b)
-                .copied()
-                .unwrap_or_default()
-                .cmp(&observed_counts.get(a).copied().unwrap_or_default())
-                .then_with(|| a.cmp(b))
-        }),
-        BarcodeCollisionPolicy::DropAmbiguous | BarcodeCollisionPolicy::AcceptFirstNeighbor => {
-            ranked_bcs.sort_unstable()
-        }
-    }
-
-    let mut correction_map = HashMap::with_capacity(10 * ranked_bcs.len());
-    for &bc in &ranked_bcs {
+) -> Result<HashMap<u64, u64>, Box<dyn Error>> {
+    let mut correction_map = HashMap::with_capacity(10 * permit_bcs.len());
+    for &bc in permit_bcs {
         correction_map.insert(bc, bc);
     }
 
     let mut neighbors = HashSet::with_capacity(3 * bc_length + 8 * (bc_length - 1));
     let mut ambiguous = HashSet::new();
-    for &bc in &ranked_bcs {
+    for &bc in permit_bcs {
         get_all_one_edit_neighbors(bc, bc_length, &mut neighbors)?;
         for &neighbor in &neighbors {
             // An exact retained barcode always maps to itself, regardless of
@@ -1113,26 +1094,18 @@ where
                 continue;
             }
 
-            match policy {
-                BarcodeCollisionPolicy::DropAmbiguous => {
-                    if ambiguous.contains(&neighbor) {
-                        continue;
-                    }
-                    match correction_map.get(&neighbor).copied() {
-                        Some(previous) if previous != bc => {
-                            correction_map.remove(&neighbor);
-                            ambiguous.insert(neighbor);
-                        }
-                        None => {
-                            correction_map.insert(neighbor, bc);
-                        }
-                        _ => {}
-                    }
+            if ambiguous.contains(&neighbor) {
+                continue;
+            }
+            match correction_map.get(&neighbor).copied() {
+                Some(previous) if previous != bc => {
+                    correction_map.remove(&neighbor);
+                    ambiguous.insert(neighbor);
                 }
-                BarcodeCollisionPolicy::PreferMostFrequent
-                | BarcodeCollisionPolicy::AcceptFirstNeighbor => {
-                    correction_map.entry(neighbor).or_insert(bc);
+                None => {
+                    correction_map.insert(neighbor, bc);
                 }
+                _ => {}
             }
         }
     }
@@ -1233,12 +1206,11 @@ impl FromStr for InternalVersionInfo {
 
 #[cfg(test)]
 mod tests {
-    use crate::prog_opts::BarcodeCollisionPolicy;
     use crate::utils::InternalVersionInfo;
     use crate::utils::MIN_THREADS;
     use crate::utils::ProbMap;
-    use crate::utils::generate_permitlist_map_with_policy;
     use crate::utils::enforce_thread_floor;
+    use crate::utils::generate_unambiguous_permitlist_map;
     use crate::utils::generate_whitelist_set;
     use crate::utils::get_all_indels;
     use crate::utils::get_all_one_edit_neighbors;
@@ -1330,83 +1302,36 @@ mod tests {
         );
     }
 
-    fn collision_map(
-        permit_bcs: &[u64],
-        counts: &[(u64, u64)],
-        policy: BarcodeCollisionPolicy,
-    ) -> HashMap<u64, u64> {
-        let counts: HashMap<_, _> = counts.iter().copied().collect();
-        generate_permitlist_map_with_policy(permit_bcs, 2, &counts, policy).unwrap()
+    fn collision_map(permit_bcs: &[u64]) -> HashMap<u64, u64> {
+        generate_unambiguous_permitlist_map(permit_bcs, 2).unwrap()
     }
 
     #[test]
-    fn barcode_collision_policy_preserves_exact_and_unique_matches() {
-        let map = collision_map(
-            &[0, 5],
-            &[(0, 10), (5, 20)],
-            BarcodeCollisionPolicy::DropAmbiguous,
-        );
+    fn unambiguous_map_preserves_exact_and_unique_matches() {
+        let map = collision_map(&[0, 5]);
         assert_eq!(map.get(&0), Some(&0));
         assert_eq!(map.get(&5), Some(&5));
         assert_eq!(map.get(&2), Some(&0));
     }
 
     #[test]
-    fn barcode_collision_policy_drops_ambiguous_neighbors_by_default() {
-        assert_eq!(
-            BarcodeCollisionPolicy::default(),
-            BarcodeCollisionPolicy::DropAmbiguous
-        );
-        let forward = collision_map(
-            &[0, 5],
-            &[(0, 10), (5, 20)],
-            BarcodeCollisionPolicy::DropAmbiguous,
-        );
-        let reverse = collision_map(
-            &[5, 0],
-            &[(0, 10), (5, 20)],
-            BarcodeCollisionPolicy::DropAmbiguous,
-        );
+    fn unambiguous_map_drops_ambiguous_neighbors() {
+        let forward = collision_map(&[0, 5]);
+        let reverse = collision_map(&[5, 0]);
         assert!(!forward.contains_key(&1));
         assert_eq!(forward, reverse);
     }
 
     #[test]
-    fn barcode_collision_policy_prefers_frequency_then_packed_value() {
-        let frequent = collision_map(
-            &[0, 5],
-            &[(0, 10), (5, 20)],
-            BarcodeCollisionPolicy::PreferMostFrequent,
-        );
-        assert_eq!(frequent.get(&1), Some(&5));
-
-        let tied = collision_map(
-            &[5, 0],
-            &[(0, 20), (5, 20)],
-            BarcodeCollisionPolicy::PreferMostFrequent,
-        );
-        assert_eq!(tied.get(&1), Some(&0));
-    }
-
-    #[test]
-    fn barcode_collision_policy_accept_first_is_sorted_and_repeatable() {
-        let expected = collision_map(
-            &[5, 0],
-            &[(0, 10), (5, 20)],
-            BarcodeCollisionPolicy::AcceptFirstNeighbor,
-        );
-        assert_eq!(expected.get(&1), Some(&0));
+    fn unambiguous_map_is_repeatable() {
+        let expected = collision_map(&[5, 0]);
 
         std::thread::scope(|scope| {
             for iteration in 0..32 {
                 let expected = &expected;
                 scope.spawn(move || {
                     let input = if iteration % 2 == 0 { [0, 5] } else { [5, 0] };
-                    let actual = collision_map(
-                        &input,
-                        &[(0, 10), (5, 20)],
-                        BarcodeCollisionPolicy::AcceptFirstNeighbor,
-                    );
+                    let actual = collision_map(&input);
                     assert_eq!(&actual, expected);
                 });
             }


### PR DESCRIPTION
## The bug

`generate-permit-list` in any of its filtered modes (`-k`, `--expect-cells`, `--force-cells`) does not produce the same output twice on the same input.

`permit_list_from_threshold` builds `valid_bc` by iterating `hist`:

```rust
let valid_bc: Vec<u64> = hist
    .iter()
    .filter_map(|(k, v)| if v >= &min_freq { Some(*k) } else { None })
    .collect();
```

`hist` is a `HashMap` obtained by draining a `DashMap` that the parsing threads filled concurrently, so its iteration order reflects the order those threads happened to insert. That order is then load-bearing: `generate_permitlist_map` walks `valid_bc` and does `entry(neighbour).or_insert(bc)`, so a barcode one edit away from two different retained barcodes is corrected to whichever of them comes first. Change the thread interleaving and some barcodes correct elsewhere, moving UMI counts between cells.

## Reproduction

Toy dataset from the `sample_run` CI job. Three runs of `generate-permit-list -k` + `collate` + `quant -r cr-like`, same binary, same input, comparing per-barcode count vectors (re-keying each nonzero of `quants_mat.mtx` by its barcode, so row ordering is not what is being compared):

| comparison | cells with differing counts |
|---|---|
| run 1 vs run 2 (before) | 14 / 1,151 |
| run 2 vs run 3 (before) | 10 / 1,151 |
| run 1 vs run 2 (after) | **0 / 1,151** |
| run 1 vs run 3 (after) | **0 / 1,151** |

Counts move in pairs, as expected from a correction target changing: for one barcode column 8099 goes from 1 to absent while a neighbouring barcode gains it.

The `--unfiltered-pl` path does not call this function and was already stable across three runs.

## The fix

One `sort_unstable()` on `valid_bc`, with a comment explaining what depends on the order.

Which barcode *should* win an ambiguous neighbour is a separate question. Lowest packed barcode is arbitrary; resolving by observed read frequency would be more defensible, and `hist` is right there if the maintainers want that instead. This change only removes the dependence on thread scheduling, and deliberately does not relitigate the tie-break.

## Checks

- `cargo test --workspace`: 24 passed, 1 ignored, 0 failed
- `cargo clippy --workspace --all-targets`: clean
- `cargo fmt --check`: clean