### PR TITLE
perf: hash the one-edit barcode maps with ahash instead of SipHash

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -980,10 +980,22 @@ pub fn get_all_indels(bc: u64, bc_length: usize) -> Vec<u64> {
     indels
 }
 
+/// The hasher used by the one-edit barcode maps below.
+///
+/// These maps are keyed by 2-bit packed barcodes, so every hash is over eight
+/// bytes of integer. SipHash, which `HashMap::new` selects, is built to resist
+/// collision attacks on attacker-chosen byte strings, and on these keys it is
+/// about twice as slow as the ahash the rest of the crate already uses. The
+/// seeds match the ones used elsewhere in the crate, so iteration order stays
+/// fixed between runs.
+fn barcode_hasher() -> ahash::RandomState {
+    ahash::RandomState::with_seeds(2u64, 7u64, 1u64, 8u64)
+}
+
 pub fn get_all_one_edit_neighbors(
     bc: u64,
     bc_length: usize,
-    neighbors: &mut HashSet<u64>,
+    neighbors: &mut HashSet<u64, ahash::RandomState>,
 ) -> Result<(), Box<dyn Error>> {
     neighbors.clear();
 
@@ -999,11 +1011,11 @@ pub fn get_all_one_edit_neighbors(
 pub fn generate_whitelist_set(
     whitelist_bcs: &[u64],
     bc_length: usize,
-) -> Result<HashSet<u64>, Box<dyn Error>> {
+) -> Result<HashSet<u64, ahash::RandomState>, Box<dyn Error>> {
     let num_bcs = whitelist_bcs.len();
 
-    let mut one_edit_barcode_hash: HashSet<u64> = HashSet::new();
-    let mut neighbors: HashSet<u64> = HashSet::new();
+    let mut one_edit_barcode_hash: HashSet<u64, ahash::RandomState> = HashSet::default();
+    let mut neighbors: HashSet<u64, ahash::RandomState> = HashSet::default();
     one_edit_barcode_hash.reserve(10 * num_bcs);
     // reserved space for 3*length SNP
     // + 4 * (length -1) insertion
@@ -1026,10 +1038,11 @@ pub fn generate_whitelist_set(
 pub fn generate_permitlist_map(
     permit_bcs: &[u64],
     bc_length: usize,
-) -> Result<HashMap<u64, u64>, Box<dyn Error>> {
+) -> Result<HashMap<u64, u64, ahash::RandomState>, Box<dyn Error>> {
     let num_bcs = permit_bcs.len();
 
-    let mut one_edit_barcode_map: HashMap<u64, u64> = HashMap::with_capacity(10 * num_bcs);
+    let mut one_edit_barcode_map: HashMap<u64, u64, ahash::RandomState> =
+        HashMap::with_capacity_and_hasher(10 * num_bcs, barcode_hasher());
     // first insert everything already in the explicit permitlist
     for bc in permit_bcs {
         one_edit_barcode_map.insert(*bc, *bc);
@@ -1038,7 +1051,8 @@ pub fn generate_permitlist_map(
     // reserved space for 3*length SNP
     // + 4 * (length -1) insertion
     // + 4 * (length -1) deletion
-    let mut neighbors: HashSet<u64> = HashSet::with_capacity(3 * bc_length + 8 * (bc_length - 1));
+    let mut neighbors: HashSet<u64, ahash::RandomState> =
+        HashSet::with_capacity_and_hasher(3 * bc_length + 8 * (bc_length - 1), barcode_hasher());
 
     for bc in permit_bcs {
         get_all_one_edit_neighbors(*bc, bc_length, &mut neighbors)?;
@@ -1195,7 +1209,7 @@ mod tests {
 
     #[test]
     fn test_get_all_one_edit_neighbors() {
-        let mut neighbors: HashSet<u64> = HashSet::new();
+        let mut neighbors: HashSet<u64, ahash::RandomState> = HashSet::default();
         get_all_one_edit_neighbors(7, 3, &mut neighbors).unwrap();
 
         let mut output: Vec<u64> = neighbors.into_iter().collect();
@@ -1213,7 +1227,7 @@ mod tests {
 
     #[test]
     fn test_generate_whitelist_hash() {
-        let neighbors: HashSet<u64> = generate_whitelist_set(&[7], 3).unwrap();
+        let neighbors = generate_whitelist_set(&[7], 3).unwrap();
         let mut output: Vec<u64> = neighbors.into_iter().collect();
 
         output.sort_unstable();


### PR DESCRIPTION
## What

Three functions in `src/utils.rs` were the only hash containers in the crate still built with `HashMap::new` / `HashSet::new`, and therefore hashing with SipHash: `generate_permitlist_map`, `generate_whitelist_set`, `get_all_one_edit_neighbors`. Their keys are 2-bit packed barcodes, eight bytes of integer, never attacker-supplied byte strings. They now use the same seeded ahash the rest of the crate uses.

No new dependency. Seeds match the ones used elsewhere, so iteration order stays fixed between runs.

## Measurements

`cargo bench --bench barcode` (added in #169) against the toy dataset's 10x v3 permit list. Apple M-series, 16 cores, macOS 26.6, `rustc 1.97.1`. Medians over 100 samples:

| bench | before (SipHash) | after (ahash) | delta |
|---|---|---|---|
| `get_all_one_edit_neighbors` | 1.666 µs | 666.4 ns | **-60%** |
| `generate_permitlist_map/1000` | 4.757 ms | 2.485 ms | **-48%** |
| `generate_permitlist_map/10000` | 51.76 ms | 26.96 ms | **-48%** |

End to end this is small, and it would be dishonest to present it otherwise. Only the filtered `generate-permit-list` modes (`-k`, `--expect-cells`, `--force-cells`) call these functions; `--unfiltered-pl` does not touch them. On the toy dataset the knee method retains 1,151 barcodes, so the map costs single-digit milliseconds inside a 0.63s stage:

| | median of 5 interleaved runs |
|---|---|
| `generate-permit-list -k`, before | 0.628 s |
| `generate-permit-list -k`, after | 0.621 s (-1.1%, inside noise) |

The microbenchmark win is real and the end-to-end win is not measurable on this dataset. It becomes visible on runs that retain many more barcodes, since the map is built once over the retained set and costs about 2.5 ms per thousand.

## Why not foldhash or rapidhash

Both were implemented on branches and measured on the same benchmark:

| | `get_all_one_edit_neighbors` | `generate_permitlist_map/10000` |
|---|---|---|
| SipHash (today) | 1.666 µs | 51.76 ms |
| ahash (this PR) | 666 ns | 26.96 ms |
| foldhash 0.2 | 645 ns | 24.29 ms |
| rapidhash 4.5 | 617 ns | 24.42 ms |

foldhash and rapidhash are about 10% ahead of ahash here, and at the full-pipeline level all three are indistinguishable (7 interleaved runs, every phase within ±2.5% of baseline, which is the noise floor on this host).

That 10% does not pay for a second hasher in the tree, because ahash cannot leave it: **libradicl 0.17 names `ahash::RandomState` in the signature of `collate_temporary_bucket_twopass_generic`** and its siblings, rather than being generic over `S: BuildHasher`. A full swap therefore ends with both hashers compiled in. If libradicl ever makes those functions generic, the question is worth reopening; foldhash would be the candidate, since rapidhash 4.5 has no deterministic per-seed `BuildHasher` (`SeedableState::new(seed)` mixes in secrets randomized at program start, and `fixed()` takes no seed), which this codebase's fixed-seed convention needs.

## Output equivalence

Verified **stacked on #171**, and that is not incidental: on current master the filtered path does not produce the same output twice on the same input, so there is no stable baseline to compare a change against. #171 fixes that.

With #171 applied, `generate-permit-list -k` + `collate` + `quant -r cr-like`, comparing per-barcode count vectors: **0 of 1,151 cells differ**, and the canonical digests are byte-identical (`29a7f637...` both sides).

## Checks

- `cargo test --workspace`: 24 passed, 1 ignored, 0 failed
- `cargo clippy --workspace --all-targets`: clean
- `cargo fmt --check`: clean