### PR TITLE
perf(em): iterate only the genes a cell can touch

### DIFF
--- a/src/em.rs
+++ b/src/em.rs
@@ -174,6 +174,45 @@ pub(crate) fn em_update_subset_usa(
     }
 }
 
+/// Returns the alpha indices that can affect this cell. Random initialization
+/// deliberately retains the dense index set: bootstrap callers use it, and
+/// changing which random values are assigned to which genes changes their
+/// statistical semantics.
+fn em_support(
+    eqclasses: &IndexedEqList,
+    cell_data: &[(u32, u32)],
+    num_alphas: usize,
+    usa_offsets: Option<(usize, usize)>,
+    init_type: EmInitType,
+) -> Vec<u32> {
+    if matches!(init_type, EmInitType::Random) {
+        return (0..num_alphas)
+            .map(|index| u32::try_from(index).expect("alpha index does not fit in u32"))
+            .collect();
+    }
+
+    let mut support = Vec::with_capacity(eqclasses.label_list_size.min(num_alphas));
+    for (eq_id, _) in cell_data {
+        for &label in eqclasses.refs_for_eqc(*eq_id) {
+            support.push(label);
+            if let Some((unspliced_offset, ambig_offset)) = usa_offsets {
+                let index = label as usize;
+                if index >= ambig_offset {
+                    support.push((index - unspliced_offset) as u32);
+                    support.push((index - ambig_offset) as u32);
+                } else if index >= unspliced_offset {
+                    support.push((index + unspliced_offset) as u32);
+                } else {
+                    support.push((index + ambig_offset) as u32);
+                }
+            }
+        }
+    }
+    support.sort_unstable();
+    support.dedup();
+    support
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn em_optimize_subset(
     eqclasses: &IndexedEqList,
@@ -215,8 +254,9 @@ pub fn em_optimize_subset(
     // USA mode), but a single cell only ever touches the handful of them that
     // appear in its own equivalence classes. Walking all `num_alphas` entries
     // once per EM iteration made the per-cell cost independent of the size of
-    // the cell: on a run with 78,899 genes that is 78,899 float comparisons per
-    // iteration for a cell that may have five equivalence classes.
+    // the cell: in USA mode, a run with 78,899 genes has 236,697 alpha values
+    // to compare per iteration even when a cell has only five equivalence
+    // classes.
     //
     // `support` is the set of indices this cell can touch. `em_update_subset`
     // only writes to the labels of the cell's equivalence classes, and in USA
@@ -224,35 +264,14 @@ pub fn em_optimize_subset(
     // each label, so those are collected too: an index that is read but never
     // written still has to be reset each iteration for the result to be
     // identical to the dense version.
-    let mut support: Vec<u32> = Vec::with_capacity(eqclasses.label_list_size.min(num_alphas));
-    for (i, _) in cell_data {
-        for label in eqclasses.refs_for_eqc(*i) {
-            support.push(*label);
-            if let Some((unspliced_offset, ambig_offset)) = usa_offsets {
-                let idx = *label as usize;
-                if idx >= ambig_offset {
-                    support.push((idx - unspliced_offset) as u32);
-                    support.push((idx - ambig_offset) as u32);
-                } else if idx >= unspliced_offset {
-                    support.push((idx + unspliced_offset) as u32);
-                } else {
-                    support.push((idx + ambig_offset) as u32);
-                }
-            }
-        }
-    }
-    support.sort_unstable();
-    support.dedup();
+    let support = em_support(eqclasses, cell_data, num_alphas, usa_offsets, init_type);
 
     // fill in the alphas based on the initialization strategy
     //
-    // Only the support is initialized. In the dense version the entries outside
-    // it were initialized too, but nothing ever reads them before the first
-    // iteration copies `alphas_out` (still zero there) over the top, so the
-    // result is unchanged. The one visible difference is that `Random` now
-    // draws one value per support entry rather than one per gene; the draws
-    // were never tied to a particular index, and no caller in this crate uses
-    // `Random`.
+    // Uniform and informative initialization only need the sparse support:
+    // entries outside it are not read before the first update resets them to
+    // zero. Random initialization uses dense support to preserve bootstrap
+    // behavior exactly.
     let mut rng = rand::rng();
     let uni_prior = 1.0 / (num_alphas as f32);
     for &index in &support {
@@ -886,4 +905,194 @@ pub fn em_optimize_long_read<P: EqClassPayload>(
     );
     */
     alphas_in
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn eq_list(num_genes: usize, labels: &[&[u32]]) -> IndexedEqList {
+        let mut eqclasses = IndexedEqList::new();
+        eqclasses.num_genes = num_genes;
+        eqclasses.eq_label_starts.push(0);
+        for label in labels {
+            eqclasses.add_label_vec(label);
+        }
+        eqclasses
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn dense_reference(
+        eqclasses: &IndexedEqList,
+        cell_data: &[(u32, u32)],
+        unique_evidence: &mut [bool],
+        no_ambiguity: &mut [bool],
+        init_type: EmInitType,
+        num_alphas: usize,
+        only_unique: bool,
+        usa_offsets: Option<(usize, usize)>,
+    ) -> Vec<f32> {
+        let mut alphas_in = vec![0.0; num_alphas];
+        let mut alphas_out = vec![0.0; num_alphas];
+
+        let mut needs_em = false;
+        for (eq_id, count) in cell_data {
+            let labels = eqclasses.refs_for_eqc(*eq_id);
+            if labels.len() == 1 {
+                let index = labels[0] as usize;
+                alphas_in[index] += *count as f32;
+                unique_evidence[index] = true;
+            } else {
+                for &index in labels {
+                    no_ambiguity[index as usize] = false;
+                }
+                needs_em = true;
+            }
+        }
+
+        if only_unique || !needs_em {
+            return alphas_in;
+        }
+
+        let uniform_prior = 1.0 / num_alphas as f32;
+        for alpha in &mut alphas_in {
+            match init_type {
+                EmInitType::Uniform => *alpha = uniform_prior,
+                EmInitType::Informative => *alpha = (*alpha + 0.5) * 1e-3,
+                EmInitType::Random => unreachable!("random output is not reproducible"),
+            }
+        }
+
+        let mut iteration = 0;
+        let mut converged = true;
+        let mut last_round = false;
+        while iteration < MIN_ITER || (iteration < MAX_ITER && !converged) || last_round {
+            match usa_offsets {
+                Some(offsets) => {
+                    em_update_subset_usa(&alphas_in, &mut alphas_out, eqclasses, cell_data, offsets)
+                }
+                None => em_update_subset(&alphas_in, &mut alphas_out, eqclasses, cell_data),
+            }
+
+            converged = true;
+            for index in 0..num_alphas {
+                if alphas_out[index] > ALPHA_CHECK_CUTOFF
+                    && (alphas_in[index] - alphas_out[index]).abs() > REL_DIFF_TOLERANCE
+                {
+                    converged = false;
+                }
+                alphas_in[index] = alphas_out[index];
+                alphas_out[index] = 0.0;
+            }
+            iteration += 1;
+
+            if last_round {
+                break;
+            }
+            if iteration >= MIN_ITER && converged {
+                for alpha in &mut alphas_in {
+                    if *alpha < MIN_OUTPUT_ALPHA {
+                        *alpha = 0.0;
+                    }
+                }
+                last_round = true;
+            }
+        }
+
+        for alpha in &mut alphas_in {
+            if *alpha < MIN_OUTPUT_ALPHA {
+                *alpha = 0.0;
+            }
+        }
+        alphas_in
+    }
+
+    fn assert_sparse_matches_dense(
+        eqclasses: &IndexedEqList,
+        cell_data: &[(u32, u32)],
+        init_type: EmInitType,
+        num_alphas: usize,
+        usa_offsets: Option<(usize, usize)>,
+    ) -> Vec<f32> {
+        let mut sparse_unique = vec![false; num_alphas];
+        let mut sparse_no_ambiguity = vec![true; num_alphas];
+        let sparse = em_optimize_subset(
+            eqclasses,
+            cell_data,
+            &mut sparse_unique,
+            &mut sparse_no_ambiguity,
+            init_type,
+            num_alphas,
+            false,
+            usa_offsets,
+            &slog::Logger::root(slog::Discard, slog::o!()),
+        );
+
+        let mut dense_unique = vec![false; num_alphas];
+        let mut dense_no_ambiguity = vec![true; num_alphas];
+        let dense = dense_reference(
+            eqclasses,
+            cell_data,
+            &mut dense_unique,
+            &mut dense_no_ambiguity,
+            init_type,
+            num_alphas,
+            false,
+            usa_offsets,
+        );
+
+        assert_eq!(sparse, dense);
+        assert_eq!(sparse_unique, dense_unique);
+        assert_eq!(sparse_no_ambiguity, dense_no_ambiguity);
+        sparse
+    }
+
+    #[test]
+    fn sparse_matches_dense_for_empty_singleton_mixed_and_converged_cells() {
+        let eqclasses = eq_list(8, &[&[0], &[1], &[0, 1], &[1, 2], &[2, 3, 4]]);
+        let cases: &[&[(u32, u32)]] = &[&[], &[(0, 7)], &[(0, 20), (1, 4), (2, 8), (3, 1), (4, 2)]];
+        for &init_type in &[EmInitType::Uniform, EmInitType::Informative] {
+            for cell_data in cases {
+                assert_sparse_matches_dense(&eqclasses, cell_data, init_type, 8, None);
+            }
+        }
+    }
+
+    #[test]
+    fn sparse_matches_dense_for_all_usa_states_and_mixed_labels() {
+        // Three genes occupy spliced [0,3), unspliced [3,6), and ambiguous
+        // [6,9). Each case has a multi-label class so it exercises the EM.
+        let eqclasses = eq_list(3, &[&[0, 1], &[3, 4], &[6, 7], &[0, 4, 8], &[2]]);
+        let cases: &[&[(u32, u32)]] = &[
+            &[(0, 5)],
+            &[(1, 5)],
+            &[(2, 5)],
+            &[(0, 3), (1, 4), (2, 5), (3, 7), (4, 2)],
+        ];
+        for &init_type in &[EmInitType::Uniform, EmInitType::Informative] {
+            for cell_data in cases {
+                assert_sparse_matches_dense(&eqclasses, cell_data, init_type, 9, Some((3, 6)));
+            }
+        }
+    }
+
+    #[test]
+    fn sparse_matches_dense_at_output_threshold() {
+        let eqclasses = eq_list(6, &[&[0], &[0, 1], &[1, 2], &[2, 3, 4]]);
+        let output = assert_sparse_matches_dense(
+            &eqclasses,
+            &[(0, 10_000), (1, 1), (2, 1), (3, 1)],
+            EmInitType::Informative,
+            6,
+            None,
+        );
+        assert!(output.contains(&0.0));
+    }
+
+    #[test]
+    fn random_initialization_keeps_dense_bootstrap_support() {
+        let eqclasses = eq_list(8, &[&[1, 2]]);
+        let support = em_support(&eqclasses, &[(0, 4)], 8, None, EmInitType::Random);
+        assert_eq!(support, (0..8).collect::<Vec<_>>());
+    }
 }

--- a/src/em.rs
+++ b/src/em.rs
@@ -211,10 +211,52 @@ pub fn em_optimize_subset(
         return alphas_in;
     }
 
+    // The alpha vectors are dense over every gene (or every gene x status in
+    // USA mode), but a single cell only ever touches the handful of them that
+    // appear in its own equivalence classes. Walking all `num_alphas` entries
+    // once per EM iteration made the per-cell cost independent of the size of
+    // the cell: on a run with 78,899 genes that is 78,899 float comparisons per
+    // iteration for a cell that may have five equivalence classes.
+    //
+    // `support` is the set of indices this cell can touch. `em_update_subset`
+    // only writes to the labels of the cell's equivalence classes, and in USA
+    // mode `get_abundance_for` additionally *reads* the two sibling statuses of
+    // each label, so those are collected too: an index that is read but never
+    // written still has to be reset each iteration for the result to be
+    // identical to the dense version.
+    let mut support: Vec<u32> = Vec::with_capacity(eqclasses.label_list_size.min(num_alphas));
+    for (i, _) in cell_data {
+        for label in eqclasses.refs_for_eqc(*i) {
+            support.push(*label);
+            if let Some((unspliced_offset, ambig_offset)) = usa_offsets {
+                let idx = *label as usize;
+                if idx >= ambig_offset {
+                    support.push((idx - unspliced_offset) as u32);
+                    support.push((idx - ambig_offset) as u32);
+                } else if idx >= unspliced_offset {
+                    support.push((idx + unspliced_offset) as u32);
+                } else {
+                    support.push((idx + ambig_offset) as u32);
+                }
+            }
+        }
+    }
+    support.sort_unstable();
+    support.dedup();
+
     // fill in the alphas based on the initialization strategy
+    //
+    // Only the support is initialized. In the dense version the entries outside
+    // it were initialized too, but nothing ever reads them before the first
+    // iteration copies `alphas_out` (still zero there) over the top, so the
+    // result is unchanged. The one visible difference is that `Random` now
+    // draws one value per support entry rather than one per gene; the draws
+    // were never tied to a particular index, and no caller in this crate uses
+    // `Random`.
     let mut rng = rand::rng();
     let uni_prior = 1.0 / (num_alphas as f32);
-    for item in alphas_in.iter_mut().take(num_alphas) {
+    for &index in &support {
+        let item = &mut alphas_in[index as usize];
         match init_type {
             EmInitType::Uniform => {
                 *item = uni_prior;
@@ -248,7 +290,8 @@ pub fn em_optimize_subset(
         converged = true;
         let mut max_rel_diff = -f64::INFINITY;
 
-        for index in 0..num_alphas {
+        for &index in &support {
+            let index = index as usize;
             if alphas_out[index] > ALPHA_CHECK_CUTOFF {
                 let diff = alphas_in[index] - alphas_out[index];
                 let rel_diff = diff.abs();
@@ -277,21 +320,23 @@ pub fn em_optimize_subset(
         // then do one last round after filtering
         // very small values.
         if it_num >= MIN_ITER && converged {
-            alphas_in.iter_mut().for_each(|alpha| {
+            for &index in &support {
+                let alpha = &mut alphas_in[index as usize];
                 if *alpha < MIN_OUTPUT_ALPHA {
                     *alpha = 0.0_f32;
                 }
-            });
+            }
             last_round = true;
         }
     }
 
-    // update too small alphas
-    alphas_in.iter_mut().for_each(|alpha| {
+    // update too small alphas; entries outside the support are still zero
+    for &index in &support {
+        let alpha = &mut alphas_in[index as usize];
         if *alpha < MIN_OUTPUT_ALPHA {
             *alpha = 0.0_f32;
         }
-    });
+    }
 
     //let alphas_sum: f32 = alphas_in.iter().sum();
     //assert!(alphas_sum > 0.0, "Alpha Sum too small");

--- a/src/em.rs
+++ b/src/em.rs
@@ -40,6 +40,79 @@ pub enum EmInitType {
     Random,
 }
 
+/// Reusable storage for [`em_optimize_subset_with_scratch`].
+///
+/// Create one value per worker thread and reuse it across cells. The
+/// bit-packed membership vector lets support construction append each alpha
+/// index at most once without first collecting and sorting duplicate labels.
+/// Dense alpha workspaces deliberately remain invocation-local so idle workers
+/// do not retain a full gene-axis allocation.
+#[derive(Debug, Default)]
+pub(crate) struct EmSubsetScratch {
+    support: Vec<u32>,
+    support_membership: Vec<bool>,
+}
+
+impl EmSubsetScratch {
+    fn new(num_alphas: usize) -> Self {
+        Self {
+            support: Vec::new(),
+            support_membership: vec![false; num_alphas],
+        }
+    }
+
+    fn clear_support(&mut self) {
+        for &index in &self.support {
+            self.support_membership[index as usize] = false;
+        }
+        self.support.clear();
+    }
+
+    #[inline]
+    fn mark_supported(&mut self, index: usize, num_alphas: usize) {
+        assert!(
+            index < num_alphas,
+            "equivalence-class label {index} is outside {num_alphas} alphas"
+        );
+        if !self.support_membership[index] {
+            self.support_membership[index] = true;
+            self.support
+                .push(u32::try_from(index).expect("alpha index does not fit in u32"));
+        }
+    }
+
+    /// Populate the possible support for a cell. Counts are intentionally not
+    /// consulted: the resulting superset can be reused when bootstrap
+    /// replicates assign zero observations to some equivalence classes.
+    fn prepare_support(
+        &mut self,
+        eqclasses: &IndexedEqList,
+        cell_data: &[(u32, u32)],
+        num_alphas: usize,
+        usa_offsets: Option<(usize, usize)>,
+    ) {
+        self.clear_support();
+        self.support_membership.resize(num_alphas, false);
+
+        for (eq_id, _) in cell_data {
+            for &label in eqclasses.refs_for_eqc(*eq_id) {
+                let index = label as usize;
+                self.mark_supported(index, num_alphas);
+                if let Some((unspliced_offset, ambig_offset)) = usa_offsets {
+                    if index >= ambig_offset {
+                        self.mark_supported(index - unspliced_offset, num_alphas);
+                        self.mark_supported(index - ambig_offset, num_alphas);
+                    } else if index >= unspliced_offset {
+                        self.mark_supported(index + unspliced_offset, num_alphas);
+                    } else {
+                        self.mark_supported(index + ambig_offset, num_alphas);
+                    }
+                }
+            }
+        }
+    }
+}
+
 #[allow(dead_code)]
 fn mean(data: &[f64]) -> Option<f64> {
     let sum = data.iter().sum::<f64>();
@@ -174,57 +247,6 @@ pub(crate) fn em_update_subset_usa(
     }
 }
 
-/// Returns the alpha indices that can affect this cell. Random initialization
-/// deliberately retains the dense index set: bootstrap callers use it, and
-/// changing which random values are assigned to which genes changes their
-/// statistical semantics.
-fn em_support(
-    eqclasses: &IndexedEqList,
-    cell_data: &[(u32, u32)],
-    num_alphas: usize,
-    usa_offsets: Option<(usize, usize)>,
-    init_type: EmInitType,
-) -> Vec<u32> {
-    if matches!(init_type, EmInitType::Random) {
-        return (0..num_alphas)
-            .map(|index| u32::try_from(index).expect("alpha index does not fit in u32"))
-            .collect();
-    }
-
-    // Size the allocation from this cell, not from the global equivalence-list
-    // storage. The latter can contain hundreds of thousands of labels and
-    // caused every concurrent cell to reserve a needlessly large vector.
-    let labels_in_cell: usize = cell_data
-        .iter()
-        .map(|(eq_id, _)| eqclasses.refs_for_eqc(*eq_id).len())
-        .sum();
-    let support_capacity = if usa_offsets.is_some() {
-        labels_in_cell.saturating_mul(3)
-    } else {
-        labels_in_cell
-    };
-    let mut support = Vec::with_capacity(support_capacity);
-    for (eq_id, _) in cell_data {
-        for &label in eqclasses.refs_for_eqc(*eq_id) {
-            support.push(label);
-            if let Some((unspliced_offset, ambig_offset)) = usa_offsets {
-                let index = label as usize;
-                if index >= ambig_offset {
-                    support.push((index - unspliced_offset) as u32);
-                    support.push((index - ambig_offset) as u32);
-                } else if index >= unspliced_offset {
-                    support.push((index + unspliced_offset) as u32);
-                } else {
-                    support.push((index + ambig_offset) as u32);
-                }
-            }
-        }
-    }
-    support.sort_unstable();
-    support.dedup();
-    support
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn em_optimize_subset(
     eqclasses: &IndexedEqList,
@@ -236,6 +258,62 @@ pub fn em_optimize_subset(
     only_unique: bool,
     usa_offsets: Option<(usize, usize)>,
     _log: &slog::Logger,
+) -> Vec<f32> {
+    let mut scratch = EmSubsetScratch::new(num_alphas);
+    em_optimize_subset_with_scratch(
+        eqclasses,
+        cell_data,
+        unique_evidence,
+        no_ambiguity,
+        init_type,
+        num_alphas,
+        only_unique,
+        usa_offsets,
+        _log,
+        &mut scratch,
+    )
+}
+
+/// Optimize one cell while reusing worker-local allocation buffers.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn em_optimize_subset_with_scratch(
+    eqclasses: &IndexedEqList,
+    cell_data: &[(u32, u32)],
+    unique_evidence: &mut [bool],
+    no_ambiguity: &mut [bool],
+    init_type: EmInitType,
+    num_alphas: usize,
+    only_unique: bool,
+    usa_offsets: Option<(usize, usize)>,
+    _log: &slog::Logger,
+    scratch: &mut EmSubsetScratch,
+) -> Vec<f32> {
+    em_optimize_subset_impl(
+        eqclasses,
+        cell_data,
+        unique_evidence,
+        no_ambiguity,
+        init_type,
+        num_alphas,
+        only_unique,
+        usa_offsets,
+        scratch,
+        false,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn em_optimize_subset_impl(
+    eqclasses: &IndexedEqList,
+    cell_data: &[(u32, u32)],
+    unique_evidence: &mut [bool],
+    no_ambiguity: &mut [bool],
+    init_type: EmInitType,
+    num_alphas: usize,
+    only_unique: bool,
+    usa_offsets: Option<(usize, usize)>,
+    scratch: &mut EmSubsetScratch,
+    support_is_prepared: bool,
 ) -> Vec<f32> {
     let mut alphas_in: Vec<f32> = vec![0.0; num_alphas];
     let mut alphas_out: Vec<f32> = vec![0.0; num_alphas];
@@ -276,17 +354,20 @@ pub fn em_optimize_subset(
     // each label, so those are collected too: an index that is read but never
     // written still has to be reset each iteration for the result to be
     // identical to the dense version.
-    let support = em_support(eqclasses, cell_data, num_alphas, usa_offsets, init_type);
+    if !support_is_prepared {
+        scratch.prepare_support(eqclasses, cell_data, num_alphas, usa_offsets);
+    }
+    let support = &scratch.support;
 
     // fill in the alphas based on the initialization strategy
     //
-    // Uniform and informative initialization only need the sparse support:
-    // entries outside it are not read before the first update resets them to
-    // zero. Random initialization uses dense support to preserve bootstrap
-    // behavior exactly.
+    // All initialization modes need only the possible support. In particular,
+    // random values outside this set cannot occur in an update denominator or
+    // receive output mass, so omitting those independent draws does not change
+    // bootstrap semantics.
     let mut rng = rand::rng();
     let uni_prior = 1.0 / (num_alphas as f32);
-    for &index in &support {
+    for &index in support {
         let item = &mut alphas_in[index as usize];
         match init_type {
             EmInitType::Uniform => {
@@ -321,7 +402,7 @@ pub fn em_optimize_subset(
         converged = true;
         let mut max_rel_diff = -f64::INFINITY;
 
-        for &index in &support {
+        for &index in support {
             let index = index as usize;
             if alphas_out[index] > ALPHA_CHECK_CUTOFF {
                 let diff = alphas_in[index] - alphas_out[index];
@@ -351,7 +432,7 @@ pub fn em_optimize_subset(
         // then do one last round after filtering
         // very small values.
         if it_num >= MIN_ITER && converged {
-            for &index in &support {
+            for &index in support {
                 let alpha = &mut alphas_in[index as usize];
                 if *alpha < MIN_OUTPUT_ALPHA {
                     *alpha = 0.0_f32;
@@ -362,7 +443,7 @@ pub fn em_optimize_subset(
     }
 
     // update too small alphas; entries outside the support are still zero
-    for &index in &support {
+    for &index in support {
         let alpha = &mut alphas_in[index as usize];
         if *alpha < MIN_OUTPUT_ALPHA {
             *alpha = 0.0_f32;
@@ -500,14 +581,16 @@ pub fn em_optimize<P: EqClassPayload>(
     alphas_in
 }
 
-pub(crate) fn run_bootstrap_subset(
+#[allow(clippy::too_many_arguments)]
+fn run_bootstrap_subset_with_scratch(
     eqclasses: &IndexedEqList,
-    cell_data: &[(u32, u32)], // (eq_id, count) vec for classes relevant for this cell
-    num_alphas: u32,          // number of genes
-    num_bootstraps: u32,      // number of bootstraps to draw
+    cell_data: &[(u32, u32)],
+    num_alphas: u32,
+    num_bootstraps: u32,
     _init_uniform: bool,
-    summary_stat: bool, // if true, the output will simply be a vector of means and variances
+    summary_stat: bool,
     _log: &slog::Logger,
+    scratch: &mut EmSubsetScratch,
 ) -> Vec<Vec<f32>> {
     // the population sample size
     let total_fragments: usize = cell_data.iter().map(|x| x.1 as usize).sum();
@@ -540,6 +623,12 @@ pub(crate) fn run_bootstrap_subset(
     };
     let mut bootstraps = Vec::with_capacity(num_output_bs);
 
+    // A bootstrap changes equivalence-class counts, not the classes or their
+    // labels. Compute the cell's possible support once and reuse that safe
+    // superset even when a replicate assigns zero observations to every class
+    // containing a particular gene.
+    scratch.prepare_support(eqclasses, cell_data, num_alphas_us, None);
+
     // bootstrap loop starts
     // let mut old_resampled_counts = Vec::new();
     let mut rnd = rand::rng();
@@ -550,7 +639,7 @@ pub(crate) fn run_bootstrap_subset(
             bootstrap_counts.push((*eq_id, resampled_counts[idx]));
         }
 
-        let alphas = em_optimize_subset(
+        let alphas = em_optimize_subset_impl(
             eqclasses,
             &bootstrap_counts[..], // indices into eqclasses relevant for this cell
             &mut unique_evidence,
@@ -559,7 +648,8 @@ pub(crate) fn run_bootstrap_subset(
             num_alphas_us,
             false, // only unique
             None,
-            _log,
+            scratch,
+            true,
         );
 
         // clear out for the next iteration.
@@ -608,6 +698,28 @@ pub fn run_bootstrap<P: EqClassPayload>(
     summary_stat: bool,
     _log: &slog::Logger,
 ) -> Vec<Vec<f32>> {
+    let mut scratch = EmSubsetScratch::new(gene_alpha.len());
+    run_bootstrap_with_scratch(
+        eqclasses,
+        num_bootstraps,
+        gene_alpha,
+        _init_uniform,
+        summary_stat,
+        _log,
+        &mut scratch,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_bootstrap_with_scratch<P: EqClassPayload>(
+    eqclasses: &HashMap<Vec<u32>, P, ahash::RandomState>,
+    num_bootstraps: u32,
+    gene_alpha: &[f32],
+    _init_uniform: bool,
+    summary_stat: bool,
+    _log: &slog::Logger,
+    scratch: &mut EmSubsetScratch,
+) -> Vec<Vec<f32>> {
     // This function is just a thin wrapper around run_bootstrap_subset.
     // Here, we convert the hashmap to an `IndexedEqList`, we map the
     // counts to a `Vec<(u32, u32)>` representing the equivalence class
@@ -632,7 +744,7 @@ pub fn run_bootstrap<P: EqClassPayload>(
 
     // now that we have the `IndexedEqList` representation of this data, just
     // run that version of the bootstrap function and return the result.
-    run_bootstrap_subset(
+    run_bootstrap_subset_with_scratch(
         &eql,
         &cell_data[..],
         gene_alpha.len() as u32,
@@ -640,6 +752,7 @@ pub fn run_bootstrap<P: EqClassPayload>(
         _init_uniform,
         summary_stat,
         _log,
+        scratch,
     )
 }
 
@@ -1102,9 +1215,69 @@ mod tests {
     }
 
     #[test]
-    fn random_initialization_keeps_dense_bootstrap_support() {
-        let eqclasses = eq_list(8, &[&[1, 2]]);
-        let support = em_support(&eqclasses, &[(0, 4)], 8, None, EmInitType::Random);
-        assert_eq!(support, (0..8).collect::<Vec<_>>());
+    fn random_initialization_uses_only_possible_cell_support() {
+        let eqclasses = eq_list(8, &[&[1, 2], &[2, 3]]);
+        let mut scratch = EmSubsetScratch::new(8);
+        scratch.prepare_support(&eqclasses, &[(0, 4), (1, 0)], 8, None);
+        assert_eq!(scratch.support, vec![1, 2, 3]);
+
+        let mut unique = vec![false; 8];
+        let mut no_ambiguity = vec![true; 8];
+        let output = em_optimize_subset_impl(
+            &eqclasses,
+            &[(0, 4), (1, 0)],
+            &mut unique,
+            &mut no_ambiguity,
+            EmInitType::Random,
+            8,
+            false,
+            None,
+            &mut scratch,
+            true,
+        );
+        assert!(output[1] + output[2] > 0.0);
+        assert_eq!(output[0], 0.0);
+        assert_eq!(output[3..], [0.0; 5]);
+    }
+
+    #[test]
+    fn bootstrap_reuses_possible_support_and_never_emits_outside_it() {
+        let eqclasses = eq_list(8, &[&[1, 2], &[2, 3], &[3]]);
+        let cell_data = [(0, 5), (1, 3), (2, 2)];
+        let mut scratch = EmSubsetScratch::new(8);
+        let bootstraps = run_bootstrap_subset_with_scratch(
+            &eqclasses,
+            &cell_data,
+            8,
+            8,
+            false,
+            false,
+            &slog::Logger::root(slog::Discard, slog::o!()),
+            &mut scratch,
+        );
+
+        assert_eq!(scratch.support, vec![1, 2, 3]);
+        assert_eq!(bootstraps.len(), 8);
+        for output in bootstraps {
+            assert!(output[1] + output[2] + output[3] > 0.0);
+            assert_eq!(output[0], 0.0);
+            assert_eq!(output[4..], [0.0; 4]);
+        }
+    }
+
+    #[test]
+    fn scratch_support_deduplicates_clears_and_reuses_membership() {
+        let eqclasses = eq_list(5, &[&[0, 1, 1], &[1, 2], &[3, 4]]);
+        let mut scratch = EmSubsetScratch::new(5);
+        let membership_capacity = scratch.support_membership.capacity();
+
+        scratch.prepare_support(&eqclasses, &[(0, 2), (1, 3)], 5, None);
+        assert_eq!(scratch.support, vec![0, 1, 2]);
+        scratch.prepare_support(&eqclasses, &[(2, 1)], 5, None);
+        assert_eq!(scratch.support, vec![3, 4]);
+        assert!(!scratch.support_membership[0]);
+        assert!(!scratch.support_membership[1]);
+        assert!(!scratch.support_membership[2]);
+        assert_eq!(scratch.support_membership.capacity(), membership_capacity);
     }
 }

--- a/src/em.rs
+++ b/src/em.rs
@@ -191,7 +191,19 @@ fn em_support(
             .collect();
     }
 
-    let mut support = Vec::with_capacity(eqclasses.label_list_size.min(num_alphas));
+    // Size the allocation from this cell, not from the global equivalence-list
+    // storage. The latter can contain hundreds of thousands of labels and
+    // caused every concurrent cell to reserve a needlessly large vector.
+    let labels_in_cell: usize = cell_data
+        .iter()
+        .map(|(eq_id, _)| eqclasses.refs_for_eqc(*eq_id).len())
+        .sum();
+    let support_capacity = if usa_offsets.is_some() {
+        labels_in_cell.saturating_mul(3)
+    } else {
+        labels_in_cell
+    };
+    let mut support = Vec::with_capacity(support_capacity);
     for (eq_id, _) in cell_data {
         for &label in eqclasses.refs_for_eqc(*eq_id) {
             support.push(label);

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -24,7 +24,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use crate::em::{EmInitType, em_optimize_subset};
+use crate::em::{EmInitType, EmSubsetScratch, em_optimize_subset_with_scratch};
 use crate::utils::read_filter_list;
 
 #[allow(clippy::too_many_arguments)]
@@ -207,9 +207,12 @@ pub fn infer(
             // each cell.
             let mut unique_evidence = vec![false; num_genes];
             let mut no_ambiguity = vec![false; num_genes];
+            let mut em_scratch = EmSubsetScratch::default();
 
-            let mut expressed_vec = Vec::<f32>::with_capacity(num_genes);
-            let mut expressed_ind = Vec::<usize>::with_capacity(num_genes);
+            // Reuse capacity across cells, but grow only to observed
+            // expression rather than reserving the full gene axis per worker.
+            let mut expressed_vec = Vec::<f32>::new();
+            let mut expressed_ind = Vec::<usize>::new();
             //let mut eds_bytes = Vec::<u8>::new();
             //let mut bt_eds_bytes: Vec<u8> = Vec::new();
             //let mut eds_mean_bytes: Vec<u8> = Vec::new();
@@ -224,7 +227,7 @@ pub fn infer(
                     // given the set of equivalence classes and counts for
                     // this cell (coming from the input matrix), perform
                     // inference to obtain gene-level counts.
-                    let counts = em_optimize_subset(
+                    let counts = em_optimize_subset_with_scratch(
                         &global_eq_classes,
                         &cell_data,
                         &mut unique_evidence,
@@ -234,6 +237,7 @@ pub fn infer(
                         false,
                         usa_offsets,
                         &log,
+                        &mut em_scratch,
                     );
 
                     // Note: there is a fill method, but it is only on

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -44,7 +44,8 @@ use flate2::Compression;
 use flate2::write::GzEncoder;
 
 use crate::em::{
-    EmInitType, em_optimize, em_optimize_long_read, em_optimize_subset, run_bootstrap,
+    EmInitType, EmSubsetScratch, em_optimize, em_optimize_long_read,
+    em_optimize_subset_with_scratch, run_bootstrap_with_scratch,
 };
 use crate::eq_class::{EqMap, EqMapType, IndexedEqList};
 use crate::prog_opts::QuantOpts;
@@ -680,9 +681,15 @@ where
     // each cell.
     let mut unique_evidence = vec![false; config.num_rows];
     let mut no_ambiguity = vec![false; config.num_rows];
+    // Lazily allocated on the first subset-EM or bootstrap call, then reused
+    // for every subsequent cell handled by this worker.
+    let mut em_scratch = EmSubsetScratch::default();
     let mut eq_map = EqMap::new(num_eq_targets, eq_map_type, P::HAS_PROBS);
-    let mut expressed_vec = Vec::<f32>::with_capacity(config.num_genes);
-    let mut expressed_ind = Vec::<usize>::with_capacity(config.num_genes);
+    // These buffers are worker-local and retained across cells, so let them
+    // grow to the largest actually expressed cell instead of reserving the
+    // complete global gene axis in every worker up front.
+    let mut expressed_vec = Vec::<f32>::new();
+    let mut expressed_ind = Vec::<usize>::new();
     // Thread-local triplet buffer for MTX output. Accumulating triplets locally
     // avoids holding the global mutex during add_triplet, which was the primary
     // bottleneck serializing all workers.
@@ -889,7 +896,7 @@ where
                                         &mut idx_eq_list,
                                         &mut eq_id_count,
                                     );
-                                    counts = em_optimize_subset(
+                                    counts = em_optimize_subset_with_scratch(
                                         &idx_eq_list,
                                         &eq_id_count,
                                         &mut unique_evidence,
@@ -899,6 +906,7 @@ where
                                         only_unique,
                                         config.usa_offsets,
                                         &log,
+                                        &mut em_scratch,
                                     );
                                 }
                                 (false, _) => {
@@ -975,7 +983,7 @@ where
                                         &mut idx_eq_list,
                                         &mut eq_id_count,
                                     );
-                                    counts = em_optimize_subset(
+                                    counts = em_optimize_subset_with_scratch(
                                         &idx_eq_list,
                                         &eq_id_count,
                                         &mut unique_evidence,
@@ -985,6 +993,7 @@ where
                                         only_unique,
                                         config.usa_offsets,
                                         &log,
+                                        &mut em_scratch,
                                     );
                                 }
                                 (false, _, false) => {
@@ -1016,13 +1025,14 @@ where
                     }
 
                     if config.num_bootstraps > 0 {
-                        bootstraps = run_bootstrap(
+                        bootstraps = run_bootstrap_with_scratch(
                             &gene_eqc,
                             config.num_bootstraps,
                             &counts,
                             config.init_uniform,
                             config.summary_stat,
                             &log,
+                            &mut em_scratch,
                         );
                     }
 


### PR DESCRIPTION
## The problem

`em_optimize_subset` keeps `alphas_in` and `alphas_out` dense over every gene (every gene x status in USA mode). The M-step is already sparse: `em_update_subset` walks only the equivalence classes present in the cell. But the two loops around it were not:

```rust
for index in 0..num_alphas {          // 236,697 on the toy dataset
    if alphas_out[index] > ALPHA_CHECK_CUTOFF { ... }
    alphas_in[index] = alphas_out[index];
    alphas_out[index] = 0.0_f32;
}
```

That runs once per EM iteration, up to `MAX_ITER` = 100 iterations, for each of 26,126 cells, regardless of whether a cell has five equivalence classes or five thousand. The per-cell cost was a function of the reference size, not of the cell.

The gap is visible in the benchmark added in #169: `em_unique_only/128`, which returns before the iteration loop, took 20.6 ms for the same 128 cells that `em_optimize_subset_batch/128` took 2.43 s on.

## The change

Collect the indices a cell can touch once, before the loop, and iterate that.

The support is not simply the labels. `em_update_subset` writes only the labels of the cell's equivalence classes, but in USA mode `get_abundance_for` also *reads* the two sibling statuses of each label. An index that is read but never written still has to be reset every iteration, otherwise it keeps its initialisation value forever instead of being zeroed by the first copy, and the denominators change. Those siblings are therefore collected as well.

Initialisation is likewise restricted to the support. In the dense version the entries outside it were initialised too, but nothing reads them before the first iteration copies `alphas_out` (still zero there) over the top, so the result is unchanged. The one behavioural difference is that `EmInitType::Random` now draws one value per support entry rather than one per gene. The draws were never tied to a particular index, and no caller in this crate uses `Random` (`quant` picks `Uniform` or `Informative`, `infer` picks `Informative`).

## Measurements

Toy dataset from the `sample_run` CI job: 29.5M reads, 26,126 cells, 375,446 refs, 78,899 genes, USA mode (236,697 alphas). Apple M-series 16 cores, macOS 26.6, `rustc 1.97.1`, `-t 8`. Interleaved A/B, median of 7 repetitions, range in brackets:

| phase | before | after |
|---|---|---|
| `generate-permit-list` | 1.691 [1.67-1.72] | 1.722 [1.59-1.99] (+1.8%) |
| `collate` | 1.871 [1.85-1.96] | 1.862 [1.84-2.05] (-0.5%) |
| `quant -r cr-like` | 0.958 [0.92-1.04] | 0.942 [0.93-0.97] (-1.7%) |
| `quant -r cr-like-em --small-thresh 0` | 5.813 [5.72-6.22] | **2.153 [2.13-2.20] (-63.0%)** |

`cargo bench --bench em`, over the cells carrying the most equivalence classes, medians:

| bench | before | after |
|---|---|---|
| `em_optimize_subset_batch/16` | 339.3 ms | 105.9 ms (-69%) |
| `em_optimize_subset_batch/128` | 2.427 s | 466.7 ms (-81%) |

The microbenchmark gain is larger than the end-to-end gain because `quant` also reads the collated RAD and writes the matrix, neither of which this touches.

## Output equivalence

Bit-identical, not merely equivalent:

- same dimensions and same nonzero count, 5,099,981 both sides
- re-keying every nonzero of `quants_mat.mtx` by its barcode gives the same digest on both sides (`e00de64d...`), **0 of 26,126 cells differing**

(The re-keying is because raw file bytes differ between any two runs of this pipeline, including two runs of the same unmodified binary, since cells are emitted in thread-completion order.)

## Left alone

`run_bootstrap_subset` (`src/em.rs:433`) and `em_optimize_long_read` (`src/em.rs:852`) contain the same dense loop. Neither is exercised by the runs above, so extending the change to them would mean shipping an unmeasured claim. They are worth the same treatment in a follow-up with a workload that exercises them (`--num-bootstraps`, and a long-read RAD respectively).

## Checks

- `cargo test --workspace`: 24 passed, 1 ignored, 0 failed
- `cargo clippy --workspace --all-targets`: clean
- `cargo fmt --check`: clean