### PR TITLE
feat(gpl): add opt-in frequency-weighted cell barcode correction

### DIFF
--- a/src/cellfilter.rs
+++ b/src/cellfilter.rs
@@ -9,6 +9,7 @@
 
 use crate::diagnostics;
 use crate::knee_finding;
+use crate::prog_opts::BarcodeCorrectionMode;
 use crate::prog_opts::GenPermitListOpts;
 use crate::prog_opts::SampleBarcodeOri;
 use crate::prog_opts::SampleCorrectionMode;
@@ -99,6 +100,89 @@ fn populate_unfiltered_barcode_map<T: Read>(
         }
     }
     hm
+}
+
+/// What happened to one unmatched barcode.
+enum CorrectionOutcome {
+    /// Correct it to this retained barcode.
+    Corrected(u64),
+    /// It has neighbours in the retained list, but none of them wins.
+    Ambiguous,
+    /// It has no neighbour in the retained list at all.
+    NotFound,
+}
+
+/// The minimum share of the total likelihood the best candidate must hold for
+/// the correction to be accepted. This is Cell Ranger's
+/// `BARCODE_CONFIDENCE_THRESHOLD` (`lib/rust/barcode/src/corrector.rs`).
+const BARCODE_CONFIDENCE_THRESHOLD: f64 = 0.975;
+
+/// Resolve an unmatched barcode the way Cell Ranger does.
+///
+/// Cell Ranger walks every single-substitution neighbour of the observed
+/// barcode, keeps the ones on the whitelist, and scores each candidate by
+///
+/// ```text
+/// likelihood = P(sequencing error at this position | base quality)
+///              * (1 + observed count of the candidate)
+/// ```
+///
+/// then corrects to the best candidate when its share of the summed likelihood
+/// reaches `BARCODE_CONFIDENCE_THRESHOLD`. The `1 +` is Laplace smoothing, so a
+/// candidate that was never observed is still reachable.
+///
+/// **The quality term is absent here, and cannot be recovered.** A RAD file
+/// stores the barcode 2-bit packed and does not carry the base qualities that
+/// produced it. Cell Ranger itself uses a flat `BC_MAX_QV` for every position
+/// when no qualities are supplied, and a flat quality makes `P(error)` the same
+/// constant for every candidate, so it cancels out of the ratio: what is left
+/// is exactly the count prior. This function therefore reproduces Cell Ranger's
+/// decision rule under uniform qualities, not under the real ones.
+///
+/// The candidate set also differs: Cell Ranger scores against the whole
+/// whitelist, this scores against the barcodes alevin-fry has retained. Keeping
+/// alevin-fry's candidate set is deliberate; widening it is a different change
+/// with a much larger blast radius.
+fn posterior_correct(
+    ubc: u64,
+    barcode_len: usize,
+    bcmap2: &BarcodeLookupMap,
+    hm: &DashMap<u64, u64, ahash::RandomState>,
+) -> CorrectionOutcome {
+    let mut best: Option<(f64, u64)> = None;
+    let mut total = 0.0f64;
+    let mut num_candidates = 0usize;
+
+    for cand in afutils::get_all_snps(ubc, barcode_len) {
+        let Some(idx) = bcmap2.find_exact(cand) else {
+            continue;
+        };
+        let cbc = bcmap2.barcodes[idx];
+        if cbc == ubc {
+            continue;
+        }
+        num_candidates += 1;
+        // Laplace-smoothed count; a retained barcode always has a count, but
+        // the `+ 1` keeps the arithmetic identical to Cell Ranger's.
+        let likelihood = 1.0 + hm.get(&cbc).map_or(0, |c| *c) as f64;
+        total += likelihood;
+        // ties go to the larger packed barcode, matching Cell Ranger's
+        // `max` over `(likelihood, barcode)` pairs.
+        match best {
+            Some((bl, bb)) if (bl, bb) >= (likelihood, cbc) => {}
+            _ => best = Some((likelihood, cbc)),
+        }
+    }
+
+    if num_candidates == 0 {
+        return CorrectionOutcome::NotFound;
+    }
+    match best {
+        Some((bl, bb)) if bl / total >= BARCODE_CONFIDENCE_THRESHOLD => {
+            CorrectionOutcome::Corrected(bb)
+        }
+        _ => CorrectionOutcome::Ambiguous,
+    }
 }
 
 #[allow(clippy::unnecessary_unwrap, clippy::too_many_arguments)]
@@ -196,36 +280,54 @@ fn process_unfiltered(
     let mut corrected_list = Vec::<(u64, u64)>::with_capacity(1_000_000);
 
     for (count, ubc) in unmatched_bc.iter().dedup_with_count() {
-        // try to find the unmatched barcode, but
-        // look up to 1 edit away
-        match bcmap2.find_neighbors(*ubc, false) {
-            // if we have a match
-            (Some(x), n) => {
-                let cbc = bcmap2.barcodes[x];
-                // if the uncorrected barcode had a
-                // single, unique retained neighbor
-                if cbc != *ubc && n == 1 {
-                    // then increment the count of this
-                    // barcode by 1 (because we'll correct to it)
-                    if let Some(mut c) = hm.get_mut(&cbc) {
-                        *c += count as u64;
-                        corrected_list.push((*ubc, cbc));
+        let resolved = match gpl_opts.bc_correction_mode {
+            BarcodeCorrectionMode::Unique => {
+                // try to find the unmatched barcode, but
+                // look up to 1 edit away
+                match bcmap2.find_neighbors(*ubc, false) {
+                    // if we have a match
+                    (Some(x), n) => {
+                        let cbc = bcmap2.barcodes[x];
+                        // if the uncorrected barcode had a
+                        // single, unique retained neighbor
+                        if cbc != *ubc && n == 1 {
+                            CorrectionOutcome::Corrected(cbc)
+                        } else if n > 1 {
+                            // if we had > 1 single-mismatch neighbor
+                            // then don't keep the barcode, but remember
+                            // the count of such events
+                            CorrectionOutcome::Ambiguous
+                        } else {
+                            CorrectionOutcome::NotFound
+                        }
                     }
-                    // this counts as an approximate find
-                    found_approx += count;
-                    distinct_recoverable_bc += 1;
-                }
-                // if we had > 1 single-mismatch neighbor
-                // then don't keep the barcode, but remember
-                // the count of such events
-                if n > 1 {
-                    ambig_approx += count;
+                    // if we had no single-mismatch neighbor
+                    // then this barcode is not_found and gets
+                    // dropped.
+                    (None, _) => CorrectionOutcome::NotFound,
                 }
             }
-            // if we had no single-mismatch neighbor
-            // then this barcode is not_found and gets
-            // dropped.
-            (None, _) => {
+            BarcodeCorrectionMode::Posterior => {
+                posterior_correct(*ubc, barcode_len as usize, &bcmap2, &hm)
+            }
+        };
+
+        match resolved {
+            CorrectionOutcome::Corrected(cbc) => {
+                // then increment the count of this
+                // barcode by 1 (because we'll correct to it)
+                if let Some(mut c) = hm.get_mut(&cbc) {
+                    *c += count as u64;
+                    corrected_list.push((*ubc, cbc));
+                }
+                // this counts as an approximate find
+                found_approx += count;
+                distinct_recoverable_bc += 1;
+            }
+            CorrectionOutcome::Ambiguous => {
+                ambig_approx += count;
+            }
+            CorrectionOutcome::NotFound => {
                 not_found += count;
             }
         }

--- a/src/cellfilter.rs
+++ b/src/cellfilter.rs
@@ -9,7 +9,7 @@
 
 use crate::diagnostics;
 use crate::knee_finding;
-use crate::prog_opts::BarcodeCorrectionMode;
+use crate::prog_opts::CellBarcodeCorrectionStrategy;
 use crate::prog_opts::GenPermitListOpts;
 use crate::prog_opts::SampleBarcodeOri;
 use crate::prog_opts::SampleCorrectionMode;
@@ -102,7 +102,8 @@ fn populate_unfiltered_barcode_map<T: Read>(
     hm
 }
 
-/// What happened to one unmatched barcode.
+/// What happened to one unmatched cell barcode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CorrectionOutcome {
     /// Correct it to this retained barcode.
     Corrected(u64),
@@ -112,12 +113,29 @@ enum CorrectionOutcome {
     NotFound,
 }
 
-/// The minimum share of the total likelihood the best candidate must hold for
-/// the correction to be accepted. This is Cell Ranger's
-/// `BARCODE_CONFIDENCE_THRESHOLD` (`lib/rust/barcode/src/corrector.rs`).
-const BARCODE_CONFIDENCE_THRESHOLD: f64 = 0.975;
+/// Cell Ranger's 0.975 confidence threshold, represented exactly as 39/40.
+const BARCODE_CONFIDENCE_NUMERATOR: u128 = 39;
+const BARCODE_CONFIDENCE_DENOMINATOR: u128 = 40;
 
-/// Resolve an unmatched barcode the way Cell Ranger does.
+/// Capture retained-barcode weights before correcting any unmatched barcode.
+///
+/// Cell Ranger's count prior is explicitly the observed whitelist counts
+/// *prior to correction*. Keeping the weights aligned with `bcmap.barcodes`
+/// both freezes those semantics and replaces a hash-table lookup in the inner
+/// candidate loop with an indexed vector access.
+fn retained_barcode_weights(bcmap: &BarcodeLookupMap, count_for: impl Fn(u64) -> u64) -> Vec<u64> {
+    bcmap
+        .barcodes
+        .iter()
+        .map(|&barcode| {
+            count_for(barcode)
+                .checked_add(1)
+                .expect("retained barcode count overflow while applying Laplace smoothing")
+        })
+        .collect()
+}
+
+/// Resolve an unmatched barcode with the Cell Ranger-inspired frequency rule.
 ///
 /// Cell Ranger walks every single-substitution neighbour of the observed
 /// barcode, keeps the ones on the whitelist, and scores each candidate by
@@ -128,60 +146,89 @@ const BARCODE_CONFIDENCE_THRESHOLD: f64 = 0.975;
 /// ```
 ///
 /// then corrects to the best candidate when its share of the summed likelihood
-/// reaches `BARCODE_CONFIDENCE_THRESHOLD`. The `1 +` is Laplace smoothing, so a
-/// candidate that was never observed is still reachable.
+/// reaches 0.975. The `1 +` is Laplace smoothing.
 ///
 /// **The quality term is absent here, and cannot be recovered.** A RAD file
 /// stores the barcode 2-bit packed and does not carry the base qualities that
-/// produced it. Cell Ranger itself uses a flat `BC_MAX_QV` for every position
-/// when no qualities are supplied, and a flat quality makes `P(error)` the same
-/// constant for every candidate, so it cancels out of the ratio: what is left
-/// is exactly the count prior. This function therefore reproduces Cell Ranger's
-/// decision rule under uniform qualities, not under the real ones.
+/// produced it. Cell Ranger uses a flat `BC_MAX_QV` when qualities are absent;
+/// that common error probability cancels from the ratio, leaving the count
+/// prior implemented here.
 ///
 /// The candidate set also differs: Cell Ranger scores against the whole
-/// whitelist, this scores against the barcodes alevin-fry has retained. Keeping
-/// alevin-fry's candidate set is deliberate; widening it is a different change
-/// with a much larger blast radius.
-fn posterior_correct(
+/// whitelist, while this function scores against the barcodes alevin-fry has
+/// retained after applying `--min-reads`. It is therefore Cell Ranger-inspired,
+/// not an exact reproduction of Cell Ranger's correction pipeline.
+fn frequency_correct(
     ubc: u64,
     barcode_len: usize,
-    bcmap2: &BarcodeLookupMap,
-    hm: &DashMap<u64, u64, ahash::RandomState>,
+    bcmap: &BarcodeLookupMap,
+    candidate_weights: &[u64],
 ) -> CorrectionOutcome {
-    let mut best: Option<(f64, u64)> = None;
-    let mut total = 0.0f64;
-    let mut num_candidates = 0usize;
+    debug_assert!(barcode_len <= 32);
+    debug_assert_eq!(bcmap.barcodes.len(), candidate_weights.len());
 
-    for cand in afutils::get_all_snps(ubc, barcode_len) {
-        let Some(idx) = bcmap2.find_exact(cand) else {
-            continue;
-        };
-        let cbc = bcmap2.barcodes[idx];
-        if cbc == ubc {
-            continue;
-        }
-        num_candidates += 1;
-        // Laplace-smoothed count; a retained barcode always has a count, but
-        // the `+ 1` keeps the arithmetic identical to Cell Ranger's.
-        let likelihood = 1.0 + hm.get(&cbc).map_or(0, |c| *c) as f64;
-        total += likelihood;
-        // ties go to the larger packed barcode, matching Cell Ranger's
-        // `max` over `(likelihood, barcode)` pairs.
-        match best {
-            Some((bl, bb)) if (bl, bb) >= (likelihood, cbc) => {}
-            _ => best = Some((likelihood, cbc)),
+    let mut best: Option<(u64, u64)> = None;
+    let mut total_weight = 0u128;
+
+    // Generate substitutions in place. `get_all_snps` returns an allocated
+    // vector, which would otherwise allocate 3 * barcode_len entries for every
+    // distinct unmatched barcode on this hot path.
+    for bit_offset in (0..2 * barcode_len).step_by(2) {
+        let base_mask = 3u64 << bit_offset;
+        let observed_base = (ubc & base_mask) >> bit_offset;
+        let cleared = ubc & !base_mask;
+
+        for replacement in 0..4u64 {
+            if replacement == observed_base {
+                continue;
+            }
+            let candidate = cleared | (replacement << bit_offset);
+            let Some(index) = bcmap.find_exact(candidate) else {
+                continue;
+            };
+
+            let corrected = bcmap.barcodes[index];
+            let weight = candidate_weights[index];
+            total_weight += u128::from(weight);
+            // Ties go to the larger packed barcode, matching Cell Ranger's
+            // `max` over `(likelihood, barcode)` pairs.
+            match best {
+                Some(current) if current >= (weight, corrected) => {}
+                _ => best = Some((weight, corrected)),
+            }
         }
     }
 
-    if num_candidates == 0 {
-        return CorrectionOutcome::NotFound;
-    }
     match best {
-        Some((bl, bb)) if bl / total >= BARCODE_CONFIDENCE_THRESHOLD => {
-            CorrectionOutcome::Corrected(bb)
+        None => CorrectionOutcome::NotFound,
+        Some((best_weight, corrected))
+            if u128::from(best_weight) * BARCODE_CONFIDENCE_DENOMINATOR
+                >= total_weight * BARCODE_CONFIDENCE_NUMERATOR =>
+        {
+            CorrectionOutcome::Corrected(corrected)
         }
-        _ => CorrectionOutcome::Ambiguous,
+        Some(_) => CorrectionOutcome::Ambiguous,
+    }
+}
+
+fn correct_unmatched_cell_barcode(
+    ubc: u64,
+    barcode_len: usize,
+    bcmap: &BarcodeLookupMap,
+    strategy: CellBarcodeCorrectionStrategy,
+    candidate_weights: &[u64],
+) -> CorrectionOutcome {
+    match strategy {
+        CellBarcodeCorrectionStrategy::Unique => match bcmap.find_neighbors(ubc, false) {
+            (Some(index), 1) if bcmap.barcodes[index] != ubc => {
+                CorrectionOutcome::Corrected(bcmap.barcodes[index])
+            }
+            (Some(_), count) if count > 1 => CorrectionOutcome::Ambiguous,
+            _ => CorrectionOutcome::NotFound,
+        },
+        CellBarcodeCorrectionStrategy::Frequency => {
+            frequency_correct(ubc, barcode_len, bcmap, candidate_weights)
+        }
     }
 }
 
@@ -260,9 +307,16 @@ fn process_unfiltered(
         bcmap2.barcodes.len().to_formatted_string(&Locale::en)
     );
 
-    // finally, we'll go through the set of unmatched barcodes
-    // and try to rescue those that have a *unique* neighbor in the
-    // list of retained barcodes.
+    let candidate_weights = match gpl_opts.cell_bc_correction {
+        CellBarcodeCorrectionStrategy::Unique => Vec::new(),
+        CellBarcodeCorrectionStrategy::Frequency => retained_barcode_weights(&bcmap2, |barcode| {
+            hm.get(&barcode).map_or(0, |count| *count)
+        }),
+    };
+
+    // Finally, try to rescue each distinct unmatched barcode according to the
+    // selected strategy. Frequency weights were captured above and remain
+    // fixed even as corrected counts are added to `hm`.
 
     //let mut found_exact = 0usize;
     let mut found_approx = 0usize;
@@ -280,37 +334,13 @@ fn process_unfiltered(
     let mut corrected_list = Vec::<(u64, u64)>::with_capacity(1_000_000);
 
     for (count, ubc) in unmatched_bc.iter().dedup_with_count() {
-        let resolved = match gpl_opts.bc_correction_mode {
-            BarcodeCorrectionMode::Unique => {
-                // try to find the unmatched barcode, but
-                // look up to 1 edit away
-                match bcmap2.find_neighbors(*ubc, false) {
-                    // if we have a match
-                    (Some(x), n) => {
-                        let cbc = bcmap2.barcodes[x];
-                        // if the uncorrected barcode had a
-                        // single, unique retained neighbor
-                        if cbc != *ubc && n == 1 {
-                            CorrectionOutcome::Corrected(cbc)
-                        } else if n > 1 {
-                            // if we had > 1 single-mismatch neighbor
-                            // then don't keep the barcode, but remember
-                            // the count of such events
-                            CorrectionOutcome::Ambiguous
-                        } else {
-                            CorrectionOutcome::NotFound
-                        }
-                    }
-                    // if we had no single-mismatch neighbor
-                    // then this barcode is not_found and gets
-                    // dropped.
-                    (None, _) => CorrectionOutcome::NotFound,
-                }
-            }
-            BarcodeCorrectionMode::Posterior => {
-                posterior_correct(*ubc, barcode_len as usize, &bcmap2, &hm)
-            }
-        };
+        let resolved = correct_unmatched_cell_barcode(
+            *ubc,
+            barcode_len as usize,
+            &bcmap2,
+            gpl_opts.cell_bc_correction,
+            &candidate_weights,
+        );
 
         match resolved {
             CorrectionOutcome::Corrected(cbc) => {
@@ -349,13 +379,15 @@ fn process_unfiltered(
     info!(log, "Of the unmatched barcodes\n============");
     info!(
         log,
-        "\t{} had exactly 1 single-edit neighbor in the retained list",
-        found_approx.to_formatted_string(&Locale::en)
+        "\t{} were corrected to a retained barcode under the '{}' strategy",
+        found_approx.to_formatted_string(&Locale::en),
+        gpl_opts.cell_bc_correction,
     );
     info!(
         log,
-        "\t{} had >1 single-edit neighbor in the retained list",
-        ambig_approx.to_formatted_string(&Locale::en)
+        "\t{} remained ambiguous under the '{}' strategy",
+        ambig_approx.to_formatted_string(&Locale::en),
+        gpl_opts.cell_bc_correction,
     );
     info!(
         log,
@@ -964,6 +996,14 @@ fn do_generate_permit_list_multi_bc(
 
                 // Build BarcodeLookupMap from kept BCs for 1-edit correction
                 let bcmap = BarcodeLookupMap::new(kept_bcs.clone(), cell_bc_len as u32);
+                let candidate_weights = match gpl_opts.cell_bc_correction {
+                    CellBarcodeCorrectionStrategy::Unique => Vec::new(),
+                    CellBarcodeCorrectionStrategy::Frequency => {
+                        retained_barcode_weights(&bcmap, |barcode| {
+                            sample_freq_map.get(&barcode).copied().unwrap_or(0)
+                        })
+                    }
+                };
 
                 // Rescue unmatched cell BCs (not in whitelist) via 1-edit correction
                 let mut unmatched = per_sample_unmatched[sample_idx].lock().unwrap();
@@ -976,19 +1016,20 @@ fn do_generate_permit_list_multi_bc(
                 let mut corrected_list = Vec::<(u64, u64)>::new();
 
                 for (count, ubc) in unmatched.iter().dedup_with_count() {
-                    match bcmap.find_neighbors(*ubc, false) {
-                        (Some(x), n) => {
-                            let cbc = bcmap.barcodes[x];
-                            if cbc != *ubc && n == 1 {
-                                *sample_freq_map.entry(cbc).or_insert(0) += count as u64;
-                                corrected_list.push((*ubc, cbc));
-                                found_approx += count;
-                            }
-                            if n > 1 {
-                                ambig_approx += count;
-                            }
+                    match correct_unmatched_cell_barcode(
+                        *ubc,
+                        usize::from(cell_bc_len),
+                        &bcmap,
+                        gpl_opts.cell_bc_correction,
+                        &candidate_weights,
+                    ) {
+                        CorrectionOutcome::Corrected(corrected) => {
+                            *sample_freq_map.entry(corrected).or_insert(0) += count as u64;
+                            corrected_list.push((*ubc, corrected));
+                            found_approx += count;
                         }
-                        (None, _) => {
+                        CorrectionOutcome::Ambiguous => ambig_approx += count,
+                        CorrectionOutcome::NotFound => {
                             not_found += count;
                         }
                     }
@@ -996,10 +1037,11 @@ fn do_generate_permit_list_multi_bc(
 
                 info!(
                     log,
-                    "  {} unmatched BCs for sample '{}': {} rescued (1-edit), {} ambiguous, {} not found",
+                    "  {} unmatched BCs for sample '{}': {} corrected with '{}', {} ambiguous, {} not found",
                     unmatched.len(),
                     sample_name,
                     found_approx.to_formatted_string(&Locale::en),
+                    gpl_opts.cell_bc_correction,
                     ambig_approx.to_formatted_string(&Locale::en),
                     not_found.to_formatted_string(&Locale::en),
                 );
@@ -1130,6 +1172,7 @@ fn do_generate_permit_list_multi_bc(
         "unmatched_reads": unmatched_reads,
         "sample_correction_mode": format!("{:?}", gpl_opts.sample_correction_mode),
         "sample_bc_ori": format!("{:?}", gpl_opts.sample_bc_ori),
+        "cell_bc_correction": gpl_opts.cell_bc_correction.to_string(),
         "samples": sample_info_entries,
     });
     let info_path = parent.join("sample_info.json");
@@ -1145,6 +1188,7 @@ fn do_generate_permit_list_multi_bc(
         "permit-list-type": format!("{:?}", gpl_opts.fmeth),
         "multi_barcode": true,
         "num_barcodes": num_barcodes,
+        "cell_bc_correction": gpl_opts.cell_bc_correction.to_string(),
     });
     let gpl_meta_path = parent.join("generate_permit_list.json");
     let gpl_meta_file = File::create(&gpl_meta_path)?;
@@ -2341,3 +2385,92 @@ where
     }
 }
 */
+
+#[cfg(test)]
+mod cell_barcode_correction_tests {
+    use super::*;
+
+    #[test]
+    fn unique_strategy_preserves_historical_neighbor_rule() {
+        let retained = BarcodeLookupMap::new(vec![1, 5], 2);
+
+        assert_eq!(
+            correct_unmatched_cell_barcode(
+                0,
+                2,
+                &retained,
+                CellBarcodeCorrectionStrategy::Unique,
+                &[],
+            ),
+            CorrectionOutcome::Corrected(1)
+        );
+
+        let ambiguous = BarcodeLookupMap::new(vec![1, 4], 2);
+        assert_eq!(
+            correct_unmatched_cell_barcode(
+                0,
+                2,
+                &ambiguous,
+                CellBarcodeCorrectionStrategy::Unique,
+                &[],
+            ),
+            CorrectionOutcome::Ambiguous
+        );
+    }
+
+    #[test]
+    fn frequency_strategy_handles_absent_unique_ambiguous_and_threshold_cases() {
+        let absent = BarcodeLookupMap::new(vec![5], 2);
+        assert_eq!(
+            frequency_correct(0, 2, &absent, &[1]),
+            CorrectionOutcome::NotFound
+        );
+
+        let unique = BarcodeLookupMap::new(vec![1], 2);
+        assert_eq!(
+            frequency_correct(0, 2, &unique, &[1]),
+            CorrectionOutcome::Corrected(1)
+        );
+
+        let two_candidates = BarcodeLookupMap::new(vec![1, 4], 2);
+        assert_eq!(
+            frequency_correct(0, 2, &two_candidates, &[38, 2]),
+            CorrectionOutcome::Ambiguous
+        );
+        assert_eq!(
+            frequency_correct(0, 2, &two_candidates, &[39, 1]),
+            CorrectionOutcome::Corrected(1),
+            "the exact 39/40 confidence boundary must be accepted"
+        );
+    }
+
+    #[test]
+    fn frequency_weights_are_aligned_and_frozen_before_correction() {
+        let retained = BarcodeLookupMap::new(vec![4, 1], 2);
+        let mut counts = HashMap::from([(1, 38u64), (4, 0u64)]);
+        let weights = retained_barcode_weights(&retained, |barcode| counts[&barcode]);
+        assert_eq!(retained.barcodes, vec![1, 4]);
+        assert_eq!(weights, vec![39, 1]);
+
+        // Later corrections can update the count map, but must not affect the
+        // Cell Ranger prior captured before correction begins.
+        counts.insert(1, 0);
+        counts.insert(4, 1_000);
+        assert_eq!(
+            frequency_correct(0, 2, &retained, &weights),
+            CorrectionOutcome::Corrected(1)
+        );
+    }
+
+    #[test]
+    fn correction_strategy_has_stable_metadata_names_and_default() {
+        assert_eq!(
+            CellBarcodeCorrectionStrategy::default(),
+            CellBarcodeCorrectionStrategy::Unique
+        );
+        assert_eq!(
+            serde_json::to_string(&CellBarcodeCorrectionStrategy::Frequency).unwrap(),
+            "\"frequency\""
+        );
+    }
+}

--- a/src/em.rs
+++ b/src/em.rs
@@ -316,56 +316,8 @@ fn em_optimize_subset_impl(
     support_is_prepared: bool,
 ) -> Vec<f32> {
     let mut alphas_in: Vec<f32> = vec![0.0; num_alphas];
+    let mut alphas_out: Vec<f32> = vec![0.0; num_alphas];
 
-    // `alphas_out` is pure scratch: the iteration loop writes it, copies it into
-    // `alphas_in`, and zeroes it again, so it is all zeroes both on entry and on
-    // exit. Allocating it per call meant one `num_alphas`-sized zeroed
-    // allocation for every cell, which on a USA-mode run with 78,899 genes is
-    // 947 KiB x 26,126 cells of allocation and memset that does no work. Each
-    // worker thread keeps one instead.
-    ALPHAS_OUT_SCRATCH.with_borrow_mut(|alphas_out| {
-        if alphas_out.len() < num_alphas {
-            alphas_out.resize(num_alphas, 0.0);
-        }
-        debug_assert!(
-            alphas_out[..num_alphas].iter().all(|a| *a == 0.0),
-            "alphas_out scratch must be left zeroed by the previous call"
-        );
-        em_optimize_subset_inner(
-            eqclasses,
-            cell_data,
-            unique_evidence,
-            no_ambiguity,
-            init_type,
-            num_alphas,
-            only_unique,
-            usa_offsets,
-            &mut alphas_in,
-            &mut alphas_out[..num_alphas],
-        )
-    });
-    alphas_in
-}
-
-thread_local! {
-    /// Per-thread scratch for `em_optimize_subset`'s `alphas_out`.
-    static ALPHAS_OUT_SCRATCH: std::cell::RefCell<Vec<f32>> =
-        const { std::cell::RefCell::new(Vec::new()) };
-}
-
-#[allow(clippy::too_many_arguments)]
-fn em_optimize_subset_inner(
-    eqclasses: &IndexedEqList,
-    cell_data: &[(u32, u32)],
-    unique_evidence: &mut [bool],
-    no_ambiguity: &mut [bool],
-    init_type: EmInitType,
-    num_alphas: usize,
-    only_unique: bool,
-    usa_offsets: Option<(usize, usize)>,
-    alphas_in: &mut [f32],
-    alphas_out: &mut [f32],
-) {
     let mut needs_em = false;
     for (i, count) in cell_data {
         let labels = eqclasses.refs_for_eqc(*i);
@@ -385,7 +337,7 @@ fn em_optimize_subset_inner(
     // or there were no multi-mapping reads, then
     // we're done
     if only_unique || !needs_em {
-        return;
+        return alphas_in;
     }
 
     // The alpha vectors are dense over every gene (or every gene x status in
@@ -440,10 +392,10 @@ fn em_optimize_subset_inner(
         // perform one round of em update
         match usa_offsets {
             Some(otup) => {
-                em_update_subset_usa(alphas_in, alphas_out, eqclasses, cell_data, otup);
+                em_update_subset_usa(&alphas_in, &mut alphas_out, eqclasses, cell_data, otup);
             }
             None => {
-                em_update_subset(alphas_in, alphas_out, eqclasses, cell_data);
+                em_update_subset(&alphas_in, &mut alphas_out, eqclasses, cell_data);
             }
         }
 
@@ -500,6 +452,7 @@ fn em_optimize_subset_inner(
 
     //let alphas_sum: f32 = alphas_in.iter().sum();
     //assert!(alphas_sum > 0.0, "Alpha Sum too small");
+    alphas_in
 }
 
 pub fn em_update<P: EqClassPayload>(

--- a/src/em.rs
+++ b/src/em.rs
@@ -187,8 +187,56 @@ pub fn em_optimize_subset(
     _log: &slog::Logger,
 ) -> Vec<f32> {
     let mut alphas_in: Vec<f32> = vec![0.0; num_alphas];
-    let mut alphas_out: Vec<f32> = vec![0.0; num_alphas];
 
+    // `alphas_out` is pure scratch: the iteration loop writes it, copies it into
+    // `alphas_in`, and zeroes it again, so it is all zeroes both on entry and on
+    // exit. Allocating it per call meant one `num_alphas`-sized zeroed
+    // allocation for every cell, which on a USA-mode run with 78,899 genes is
+    // 947 KiB x 26,126 cells of allocation and memset that does no work. Each
+    // worker thread keeps one instead.
+    ALPHAS_OUT_SCRATCH.with_borrow_mut(|alphas_out| {
+        if alphas_out.len() < num_alphas {
+            alphas_out.resize(num_alphas, 0.0);
+        }
+        debug_assert!(
+            alphas_out[..num_alphas].iter().all(|a| *a == 0.0),
+            "alphas_out scratch must be left zeroed by the previous call"
+        );
+        em_optimize_subset_inner(
+            eqclasses,
+            cell_data,
+            unique_evidence,
+            no_ambiguity,
+            init_type,
+            num_alphas,
+            only_unique,
+            usa_offsets,
+            &mut alphas_in,
+            &mut alphas_out[..num_alphas],
+        )
+    });
+    alphas_in
+}
+
+thread_local! {
+    /// Per-thread scratch for `em_optimize_subset`'s `alphas_out`.
+    static ALPHAS_OUT_SCRATCH: std::cell::RefCell<Vec<f32>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[allow(clippy::too_many_arguments)]
+fn em_optimize_subset_inner(
+    eqclasses: &IndexedEqList,
+    cell_data: &[(u32, u32)],
+    unique_evidence: &mut [bool],
+    no_ambiguity: &mut [bool],
+    init_type: EmInitType,
+    num_alphas: usize,
+    only_unique: bool,
+    usa_offsets: Option<(usize, usize)>,
+    alphas_in: &mut [f32],
+    alphas_out: &mut [f32],
+) {
     let mut needs_em = false;
     for (i, count) in cell_data {
         let labels = eqclasses.refs_for_eqc(*i);
@@ -208,7 +256,7 @@ pub fn em_optimize_subset(
     // or there were no multi-mapping reads, then
     // we're done
     if only_unique || !needs_em {
-        return alphas_in;
+        return;
     }
 
     // fill in the alphas based on the initialization strategy
@@ -238,10 +286,10 @@ pub fn em_optimize_subset(
         // perform one round of em update
         match usa_offsets {
             Some(otup) => {
-                em_update_subset_usa(&alphas_in, &mut alphas_out, eqclasses, cell_data, otup);
+                em_update_subset_usa(alphas_in, alphas_out, eqclasses, cell_data, otup);
             }
             None => {
-                em_update_subset(&alphas_in, &mut alphas_out, eqclasses, cell_data);
+                em_update_subset(alphas_in, alphas_out, eqclasses, cell_data);
             }
         }
 
@@ -295,7 +343,6 @@ pub fn em_optimize_subset(
 
     //let alphas_sum: f32 = alphas_in.iter().sum();
     //assert!(alphas_sum > 0.0, "Alpha Sum too small");
-    alphas_in
 }
 
 pub fn em_update<P: EqClassPayload>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,7 @@ fn main() -> anyhow::Result<()> {
         .arg(
             arg!(-u --"unfiltered-pl" <UNFILTEREDPL> "uses an unfiltered external permit list")
             .value_parser(pathbuf_file_exists_validator)
+            .required_if_eq("cell-bc-correction", "frequency")
         )
         .group(ArgGroup::new("filter-method")
                .args(["knee-distance", "expect-cells", "force-cells", "valid-bc", "unfiltered-pl"])
@@ -144,8 +145,8 @@ fn main() -> anyhow::Result<()> {
                 .requires("sample-bc-list")
         )
         .arg(
-            arg!(--"bc-correction-mode" <BCMODE> "how to resolve an unmatched cell barcode that is one substitution away from more than one retained barcode: `unique` drops it (the historical behaviour), `posterior` applies Cell Ranger's rule and corrects to the best candidate when it holds at least 97.5% of the likelihood")
-                .value_parser(["unique", "posterior"])
+            arg!(--"cell-bc-correction" <STRATEGY> "cell-barcode correction strategy for --unfiltered-pl: `unique` accepts only a unique retained neighbour (the default); `frequency` applies a Cell Ranger-inspired, uniform-quality rule and accepts the most frequent retained neighbour when it has at least 97.5% of the total Laplace-smoothed weight")
+                .value_parser(["unique", "frequency"])
                 .default_value("unique")
         )
         .arg(
@@ -390,12 +391,12 @@ fn main() -> anyhow::Result<()> {
             _ => prog_opts::SampleCorrectionMode::Exact,
         };
 
-        let bc_correction_mode = match t
-            .get_one::<String>("bc-correction-mode")
+        let cell_bc_correction = match t
+            .get_one::<String>("cell-bc-correction")
             .map(|s| s.as_str())
         {
-            Some("posterior") => prog_opts::BarcodeCorrectionMode::Posterior,
-            _ => prog_opts::BarcodeCorrectionMode::Unique,
+            Some("frequency") => prog_opts::CellBarcodeCorrectionStrategy::Frequency,
+            _ => prog_opts::CellBarcodeCorrectionStrategy::Unique,
         };
 
         let sample_bc_ori = match t.get_one::<String>("sample-bc-ori").map(|s| s.as_str()) {
@@ -417,7 +418,7 @@ fn main() -> anyhow::Result<()> {
             .sample_names(sample_names)
             .sample_correction_mode(sample_correction_mode)
             .sample_bc_ori(sample_bc_ori)
-            .bc_correction_mode(bc_correction_mode)
+            .cell_bc_correction(cell_bc_correction)
             .build();
 
         match generate_permit_list(gpl_opts) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,11 @@ fn main() -> anyhow::Result<()> {
                 .requires("sample-bc-list")
         )
         .arg(
+            arg!(--"bc-correction-mode" <BCMODE> "how to resolve an unmatched cell barcode that is one substitution away from more than one retained barcode: `unique` drops it (the historical behaviour), `posterior` applies Cell Ranger's rule and corrects to the best candidate when it holds at least 97.5% of the likelihood")
+                .value_parser(["unique", "posterior"])
+                .default_value("unique")
+        )
+        .arg(
             arg!(--"sample-bc-ori" <SBCORI> "orientation of sample barcodes in the whitelist relative to the read (forward = whitelist matches read as-is; reverse = reverse-complement the whitelist before lookup, e.g. 10x Flex v2)")
                 .value_parser(["forward", "reverse"])
                 .default_value("forward")
@@ -385,6 +390,14 @@ fn main() -> anyhow::Result<()> {
             _ => prog_opts::SampleCorrectionMode::Exact,
         };
 
+        let bc_correction_mode = match t
+            .get_one::<String>("bc-correction-mode")
+            .map(|s| s.as_str())
+        {
+            Some("posterior") => prog_opts::BarcodeCorrectionMode::Posterior,
+            _ => prog_opts::BarcodeCorrectionMode::Unique,
+        };
+
         let sample_bc_ori = match t.get_one::<String>("sample-bc-ori").map(|s| s.as_str()) {
             Some("reverse") => prog_opts::SampleBarcodeOri::Reverse,
             _ => prog_opts::SampleBarcodeOri::Forward,
@@ -404,6 +417,7 @@ fn main() -> anyhow::Result<()> {
             .sample_names(sample_names)
             .sample_correction_mode(sample_correction_mode)
             .sample_bc_ori(sample_bc_ori)
+            .bc_correction_mode(bc_correction_mode)
             .build();
 
         match generate_permit_list(gpl_opts) {

--- a/src/prog_opts.rs
+++ b/src/prog_opts.rs
@@ -88,29 +88,33 @@ pub struct GenPermitListOpts<'a, 'b, 'c, 'd, 'e> {
     /// Orientation of sample barcodes in the whitelist relative to the read.
     #[builder(default = SampleBarcodeOri::Forward)]
     pub sample_bc_ori: SampleBarcodeOri,
-    /// How an unmatched barcode with more than one neighbour in the retained
-    /// list is resolved.
-    #[builder(default = BarcodeCorrectionMode::Unique)]
-    pub bc_correction_mode: BarcodeCorrectionMode,
+    /// How unmatched cell barcodes are corrected to retained barcodes when an
+    /// unfiltered external permit list is used.
+    #[builder(default)]
+    pub cell_bc_correction: CellBarcodeCorrectionStrategy,
 }
 
 /// How to resolve an unmatched barcode that is one substitution away from more
 /// than one retained barcode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-pub enum BarcodeCorrectionMode {
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CellBarcodeCorrectionStrategy {
     /// Correct only when there is exactly one such neighbour, and drop the
     /// barcode otherwise. This is what alevin-fry has always done.
+    #[default]
     Unique,
-    /// Rank the neighbours by Cell Ranger's posterior and correct to the best
-    /// one when it carries at least 97.5% of the total likelihood.
-    Posterior,
+    /// Rank retained neighbours by their Laplace-smoothed pre-correction
+    /// frequencies and accept the best one when it carries at least 97.5% of
+    /// the total weight. This is Cell Ranger's posterior decision rule under
+    /// uniform base qualities, applied to alevin-fry's retained candidates.
+    Frequency,
 }
 
-impl std::fmt::Display for BarcodeCorrectionMode {
+impl std::fmt::Display for CellBarcodeCorrectionStrategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BarcodeCorrectionMode::Unique => write!(f, "unique"),
-            BarcodeCorrectionMode::Posterior => write!(f, "posterior"),
+            Self::Unique => write!(f, "unique"),
+            Self::Frequency => write!(f, "frequency"),
         }
     }
 }

--- a/src/prog_opts.rs
+++ b/src/prog_opts.rs
@@ -88,4 +88,29 @@ pub struct GenPermitListOpts<'a, 'b, 'c, 'd, 'e> {
     /// Orientation of sample barcodes in the whitelist relative to the read.
     #[builder(default = SampleBarcodeOri::Forward)]
     pub sample_bc_ori: SampleBarcodeOri,
+    /// How an unmatched barcode with more than one neighbour in the retained
+    /// list is resolved.
+    #[builder(default = BarcodeCorrectionMode::Unique)]
+    pub bc_correction_mode: BarcodeCorrectionMode,
+}
+
+/// How to resolve an unmatched barcode that is one substitution away from more
+/// than one retained barcode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum BarcodeCorrectionMode {
+    /// Correct only when there is exactly one such neighbour, and drop the
+    /// barcode otherwise. This is what alevin-fry has always done.
+    Unique,
+    /// Rank the neighbours by Cell Ranger's posterior and correct to the best
+    /// one when it carries at least 97.5% of the total likelihood.
+    Posterior,
+}
+
+impl std::fmt::Display for BarcodeCorrectionMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BarcodeCorrectionMode::Unique => write!(f, "unique"),
+            BarcodeCorrectionMode::Posterior => write!(f, "posterior"),
+        }
+    }
 }


### PR DESCRIPTION
## What this changes

This PR adds an optional frequency-weighted correction strategy for cell barcodes used with `generate-permit-list --unfiltered-pl`:

```text
--cell-bc-correction <unique|frequency>
```

`unique` remains the default and preserves alevin-fry's historical, conservative rule: an unmatched barcode is corrected only when it has exactly one retained single-substitution neighbour. `frequency` resolves multiple retained neighbours by their Laplace-smoothed pre-correction read counts and accepts the best candidate only when it has at least 97.5% of the total candidate weight.

The name deliberately describes what the implementation can establish from a RAD file. This is Cell Ranger-inspired, but it is not an exact Cell Ranger reproduction:

- RAD stores packed barcodes without base qualities. With uniform qualities, Cell Ranger's common error-probability factor cancels and the rule reduces to the frequency prior used here.
- Cell Ranger considers the full whitelist. alevin-fry considers only barcodes retained after `--min-reads`, preserving the existing meaning of its unfiltered permit-list workflow.

The strategy applies to both ordinary RNA and per-sample multiplex RNA permit-list generation. It does not affect filtered RNA correction, sample-barcode correction, or ATAC.

## Audit repairs

The maintainer follow-up makes several correctness and quality changes:

- freezes all candidate weights before correcting any unmatched barcode, matching Cell Ranger's documented requirement that counts are observed **prior to correction** and preventing order-dependent cascading priors;
- replaces an allocated `3 * barcode_length` neighbour vector and repeated concurrent-map lookups with allocation-free substitution enumeration and an indexed weight vector;
- represents the 0.975 threshold exactly as the integer ratio 39/40;
- applies the strategy to multiplex/per-sample cell barcodes and records it in both single- and multi-barcode run metadata;
- keeps strategy-neutral logging and adds focused tests for the historical default, absent/unique/ambiguous candidates, the exact threshold, aligned weights, frozen priors, and stable serialized names;
- removes an unrelated per-thread dense EM scratch change that was included in the original commit. Sparse EM remains exactly as implemented on current `master`.

## Independent real-data evaluation

On the PBMC RAD from the alevin-fry 0.17 parity manifest (`-t 8`, pinned to eight physical cores):

| Strategy | Corrected reads | Ambiguous reads | Permit-map entries |
| --- | ---: | ---: | ---: |
| `unique` (default) | 983,308 | 62,254 | 149,885 |
| `frequency` | 1,043,664 | 1,898 | 152,024 |

The optional strategy rescues 60,356 additional reads. The default map is semantically identical to the existing reference, and the repaired frequency map is semantically identical to the submitted implementation on this dataset. Seven repeated repaired runs produced identical deserialized maps.

Seven warmed, interleaved repetitions:

| Variant | Whole GPL median (range / MAD) | Correction phase median | Peak RSS median |
| --- | ---: | ---: | ---: |
| original `unique` | 1.700 s (1.700–1.720 / 0.000) | 71.125 ms | 331,408 KiB |
| original `posterior` | 1.800 s (1.780–2.230 / 0.010) | 154.116 ms | 332,532 KiB |
| repaired `unique` | 1.700 s (1.690–1.700 / 0.000) | 71.470 ms | 338,528 KiB |
| repaired `frequency` | 1.730 s (1.730–1.740 / 0.000) | 105.784 ms | 333,048 KiB |

The optimized frequency correction phase is 31.4% faster than the submitted implementation. Whole-stage overhead versus the default is about 1.8%, and measured peak memory does not increase.

The Flex fixture also completed under both strategies. All 28 non-empty per-sample maps matched the historical path on this small fixture, and metadata records `"cell_bc_correction": "frequency"`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`: 34 passed, 1 intentionally ignored real-data test
- release build and dependency feature-tree inspection
- CLI dependency check: `frequency` requires `--unfiltered-pl`

Current fixup commit: `1978eca` (after merging current `master` at `7c7a99d`).
