### PR TITLE
feat(quant): add Cell Ranger's UMI collapsing and low-support rules

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -217,6 +217,9 @@ fn main() -> anyhow::Result<()> {
         ])
         .default_value("0") // for any other mode
         .hide(true))
+    .arg(arg!(--"umi-dedup-mode" <UMIMODE> "how UMIs are collapsed and how a UMI split across genes is resolved: `legacy` keeps UMIs as sequenced and emits an equivalence class for a tied UMI, `cellranger` collapses Hamming-distance-one UMIs within a gene and discards a UMI with no strict top gene")
+        .value_parser(["legacy", "cellranger"])
+        .default_value("legacy"))
     .arg(arg!(--"small-thresh" <SMALLTHRESH> "cells with fewer than this many reads are resolved by a fast path that applies cr-like (winner-take-all) semantics regardless of --resolution; pass 0 to resolve every cell with the requested strategy")
         .value_parser(value_parser!(usize))
         .default_value("100"))
@@ -471,6 +474,10 @@ fn main() -> anyhow::Result<()> {
         let resolution = *t.get_one::<ResolutionStrategy>("resolution").unwrap();
         let sa_model = *t.get_one::<SplicedAmbiguityModel>("sa-model").unwrap();
         let small_thresh = *t.get_one("small-thresh").unwrap();
+        let umi_dedup_mode = match t.get_one::<String>("umi-dedup-mode").map(|s| s.as_str()) {
+            Some("cellranger") => prog_opts::UmiDedupMode::CellRanger,
+            _ => prog_opts::UmiDedupMode::Legacy,
+        };
         let filter_list: Option<&PathBuf> = t.get_one("quant-subset");
         let large_graph_thresh: usize = *t.get_one("large-graph-thresh").unwrap();
         let umi_edit_dist: u32 = *t.get_one("umi-edit-dist").unwrap();
@@ -570,6 +577,7 @@ fn main() -> anyhow::Result<()> {
             .resolution(resolution)
             .sa_model(sa_model)
             .small_thresh(small_thresh)
+            .umi_dedup_mode(umi_dedup_mode)
             .large_graph_thresh(large_graph_thresh)
             .filter_list(filter_list)
             .pug_exact_umi(pug_exact_umi)
@@ -601,9 +609,10 @@ fn main() -> anyhow::Result<()> {
                                 }
                             }
                         }
-                        // if something else, just panic
+                        // anything else: surface the error rather than
+                        // replacing it with a message that says nothing
                         None => {
-                            panic!("could not quantify rad file.");
+                            return Err(e.context("could not quantify rad file"));
                         }
                     },
                 }; // end match if
@@ -626,9 +635,10 @@ fn main() -> anyhow::Result<()> {
                                 }
                             }
                         }
-                        // if something else, just panic
+                        // anything else: surface the error rather than
+                        // replacing it with a message that says nothing
                         None => {
-                            panic!("could not quantify rad file.");
+                            return Err(e.context("could not quantify rad file"));
                         }
                     },
                 }; //end quant if

--- a/src/prog_opts.rs
+++ b/src/prog_opts.rs
@@ -35,10 +35,36 @@ pub struct QuantOpts<'a, 'b, 'c, 'd, 'e, 'f, 'g> {
     pub small_thresh: usize,
     pub large_graph_thresh: usize,
     pub filter_list: Option<&'d PathBuf>,
+    /// How UMIs are collapsed and how a UMI split across genes is resolved.
+    #[builder(default = UmiDedupMode::Legacy)]
+    pub umi_dedup_mode: UmiDedupMode,
     pub cmdline: &'e str,
     pub version: &'f str,
     #[serde(skip_serializing)]
     pub log: &'g slog::Logger,
+}
+
+/// How UMIs are collapsed, and what happens to a UMI whose reads are split
+/// across several genes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum UmiDedupMode {
+    /// alevin-fry's historical behaviour: UMIs are taken as sequenced, and a
+    /// UMI whose top gene is tied contributes an equivalence class holding
+    /// every tied gene.
+    Legacy,
+    /// Cell Ranger's behaviour: collapse Hamming-distance-one UMIs within a
+    /// gene toward the more abundant one, then discard any UMI whose top gene
+    /// is not a strict winner.
+    CellRanger,
+}
+
+impl std::fmt::Display for UmiDedupMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UmiDedupMode::Legacy => write!(f, "legacy"),
+            UmiDedupMode::CellRanger => write!(f, "cellranger"),
+        }
+    }
 }
 
 /// Correction mode for sample barcodes in multi-barcode protocols.

--- a/src/pugutils.rs
+++ b/src/pugutils.rs
@@ -11,10 +11,11 @@
 use ahash::{AHasher, RandomState};
 use arrayvec::ArrayVec;
 use smallvec::SmallVec;
-use std::cmp::Ordering;
+use std::cmp::Ordering as CmpOrdering;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io;
 use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use petgraph::prelude::*;
 use petgraph::unionfind::*;
@@ -29,6 +30,7 @@ use libradicl::record::{
 use slog::{crit, info, warn};
 
 use crate::eq_class::{EqMap, EqMapType};
+use crate::prog_opts::UmiDedupMode;
 use crate::quant::SplicedAmbiguityModel;
 use crate::utils::{self as afutils, EqClassPayload};
 
@@ -611,12 +613,12 @@ fn resolve_num_molecules_crlike_from_vec_prefer_ambig<P: EqClassPayload>(
             // the new max gene.  Having a distinct max
             // also makes this UMI uniquely resolvable
             match count_aggr.cmp(&max_count) {
-                Ordering::Greater => {
+                CmpOrdering::Greater => {
                     max_count = count_aggr;
                     best_genes.clear();
                     best_genes.extend(curr_gn.iter());
                 }
-                Ordering::Equal => {
+                CmpOrdering::Equal => {
                     // if we have a tie for the max count
                     // then the current UMI isn't uniquely-unresolvable
                     // it will stay this way unless we see a bigger
@@ -624,7 +626,7 @@ fn resolve_num_molecules_crlike_from_vec_prefer_ambig<P: EqClassPayload>(
                     // "tied" gene to the equivalence class.
                     best_genes.extend(curr_gn.iter());
                 }
-                Ordering::Less => {
+                CmpOrdering::Less => {
                     // we do nothing
                 }
             }
@@ -640,7 +642,157 @@ fn resolve_num_molecules_crlike_from_vec_prefer_ambig<P: EqClassPayload>(
     }
 }
 
+/// Counters for `--umi-dedup-mode cellranger`, summed over every cell of the
+/// run. Process-wide, which is enough: one `quant` invocation is one run.
+static STAT_UMIGENES: AtomicU64 = AtomicU64::new(0);
+static STAT_CORRECTED: AtomicU64 = AtomicU64::new(0);
+static STAT_TIED_UMIS: AtomicU64 = AtomicU64::new(0);
+static STAT_DROPPED: AtomicU64 = AtomicU64::new(0);
+
+/// What the Cell Ranger UMI rules did over the whole run.
+pub struct CellRangerUmiStats {
+    /// Distinct (UMI, gene) pairs seen.
+    pub umi_genes: u64,
+    /// UMIs moved onto a Hamming-distance-one neighbour within a gene.
+    pub corrected: u64,
+    /// UMIs discarded because no gene was a strict winner.
+    pub tied_umis: u64,
+    /// (UMI, gene) pairs discarded, ties and non-winners together.
+    pub dropped: u64,
+}
+
+/// Read the counters above.
+pub fn cellranger_umi_stats() -> CellRangerUmiStats {
+    CellRangerUmiStats {
+        umi_genes: STAT_UMIGENES.load(Ordering::Relaxed),
+        corrected: STAT_CORRECTED.load(Ordering::Relaxed),
+        tied_umis: STAT_TIED_UMIS.load(Ordering::Relaxed),
+        dropped: STAT_DROPPED.load(Ordering::Relaxed),
+    }
+}
+
 #[inline]
+/// Resolve a cell's `(umi, gene, count)` triplets the way Cell Ranger does.
+///
+/// Two rules, both from `lib/rust/tx_annotation/src/mark_dups.rs` at tag
+/// `cellranger-10.0.0`:
+///
+/// 1. `correct_umis`: within a gene, a UMI is moved onto any UMI one
+///    substitution away that carries a strictly greater count, or an equal
+///    count and a lexicographically greater sequence. All destinations are
+///    chosen from the *original* counts, in a single pass; the corrections are
+///    not applied iteratively.
+///
+/// 2. `determine_low_support_umigenes`: a UMI keeps only its strict top gene.
+///    If two genes tie for the top count, the whole UMI is discarded, top genes
+///    included.
+///
+/// The corrections are applied in two stages around rule 2, exactly as Cell
+/// Ranger does it: one read is moved before the low-support decision and the
+/// remainder afterwards, which changes which UMI-genes look tied. Cell Ranger
+/// notes this is to preserve Cell Ranger 3 behaviour.
+///
+/// Comparing packed UMIs numerically is the same as comparing the sequences
+/// lexicographically: bases are packed two bits at a time with the first base
+/// in the most significant position, and the encoding A=0, C=1, G=2, T=3 is
+/// already in alphabetical order.
+///
+/// Every surviving UMI resolves to exactly one gene, so the equivalence classes
+/// this produces are always singletons.
+fn resolve_num_molecules_cellranger_from_vec<P: EqClassPayload>(
+    umi_gene_count_vec: &mut [(u64, u32, u32)],
+    umi_len: usize,
+    gene_eqclass_hash: &mut HashMap<Vec<u32>, P, ahash::RandomState>,
+) {
+    if umi_gene_count_vec.is_empty() {
+        return;
+    }
+
+    // aggregate duplicate (umi, gene) rows into one count each
+    umi_gene_count_vec.sort_unstable();
+    let mut counts: Vec<(u64, u32, i64)> = Vec::with_capacity(umi_gene_count_vec.len());
+    for &(umi, gene, ct) in umi_gene_count_vec.iter() {
+        match counts.last_mut() {
+            Some(last) if last.0 == umi && last.1 == gene => last.2 += ct as i64,
+            _ => counts.push((umi, gene, ct as i64)),
+        }
+    }
+
+    // index (umi, gene) -> position in `counts`, so the mutated lookups below
+    // are constant time
+    let mut pos: HashMap<(u64, u32), usize, ahash::RandomState> =
+        HashMap::with_capacity_and_hasher(counts.len(), RandomState::with_seeds(2, 7, 1, 8));
+    for (i, &(umi, gene, _)) in counts.iter().enumerate() {
+        pos.insert((umi, gene), i);
+    }
+
+    STAT_UMIGENES.fetch_add(counts.len() as u64, Ordering::Relaxed);
+    // rule 1, over the original counts
+    let mut corrections: Vec<(usize, usize)> = Vec::new(); // (from, to) indices
+    for (i, &(umi, gene, count)) in counts.iter().enumerate() {
+        let mut best_umi = umi;
+        let mut best_count = count;
+        for cand in afutils::get_all_snps(umi, umi_len) {
+            let cand_count = pos.get(&(cand, gene)).map_or(0i64, |&j| counts[j].2);
+            if cand_count > best_count || (cand_count == best_count && cand > best_umi) {
+                best_umi = cand;
+                best_count = cand_count;
+            }
+        }
+        if best_umi != umi {
+            let dest = pos[&(best_umi, gene)];
+            corrections.push((i, dest));
+            STAT_CORRECTED.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    // stage A: move one read per correction, then decide low support
+    let raw_counts: Vec<i64> = corrections
+        .iter()
+        .map(|&(from, _)| counts[from].2)
+        .collect();
+    for &(from, to) in &corrections {
+        counts[from].2 -= 1;
+        counts[to].2 += 1;
+    }
+
+    let mut dropped = vec![false; counts.len()];
+    let mut i = 0usize;
+    while i < counts.len() {
+        let umi = counts[i].0;
+        let mut j = i;
+        while j < counts.len() && counts[j].0 == umi {
+            j += 1;
+        }
+        let max_count = counts[i..j].iter().map(|c| c.2).max().unwrap();
+        let tied = counts[i..j].iter().filter(|c| c.2 == max_count).count() >= 2;
+        if tied {
+            STAT_TIED_UMIS.fetch_add(1, Ordering::Relaxed);
+        }
+        for k in i..j {
+            if tied || counts[k].2 < max_count {
+                dropped[k] = true;
+                STAT_DROPPED.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        i = j;
+    }
+
+    // stage B: move the remaining reads
+    for (&(from, to), raw) in corrections.iter().zip(raw_counts.iter()) {
+        counts[from].2 -= raw - 1;
+        counts[to].2 += raw - 1;
+    }
+
+    for (k, &(_umi, gene, count)) in counts.iter().enumerate() {
+        if dropped[k] || count <= 0 {
+            continue;
+        }
+        let labels = vec![gene];
+        gene_eqclass_hash.entry(labels).or_insert(P::new(1)).inc();
+    }
+}
+
 fn resolve_num_molecules_crlike_from_vec<P: EqClassPayload>(
     umi_gene_count_vec: &mut [(u64, u32, u32)],
     gene_eqclass_hash: &mut HashMap<Vec<u32>, P, ahash::RandomState>,
@@ -707,7 +859,7 @@ fn resolve_num_molecules_crlike_from_vec<P: EqClassPayload>(
             // the new max gene.  Having a distinct max
             // also makes this UMI uniquely resolvable
             match count_aggr.cmp(&max_count) {
-                Ordering::Greater => {
+                CmpOrdering::Greater => {
                     max_count = count_aggr;
                     // we want to avoid the case that we are just
                     // updating the count of the best gene above and
@@ -724,7 +876,7 @@ fn resolve_num_molecules_crlike_from_vec<P: EqClassPayload>(
                         }
                     }
                 }
-                Ordering::Equal => {
+                CmpOrdering::Equal => {
                     // if we have a tie for the max count
                     // then the current UMI isn't uniquely-unresolvable
                     // it will stay this way unless we see a bigger
@@ -732,7 +884,7 @@ fn resolve_num_molecules_crlike_from_vec<P: EqClassPayload>(
                     // "tied" gene to the equivalence class.
                     best_genes.push(gn);
                 }
-                Ordering::Less => {
+                CmpOrdering::Less => {
                     // we do nothing
                 }
             }
@@ -748,12 +900,15 @@ fn resolve_num_molecules_crlike_from_vec<P: EqClassPayload>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn get_num_molecules_cell_ranger_like_small<B, R, P: EqClassPayload>(
     cell_chunk: &mut chunk::Chunk<R>,
     tid_to_gid: &[u32],
     _num_genes: usize,
     gene_eqclass_hash: &mut HashMap<Vec<u32>, P, ahash::RandomState>,
     sa_model: SplicedAmbiguityModel,
+    umi_dedup_mode: UmiDedupMode,
+    umi_len: usize,
     _log: &slog::Logger,
 ) where
     B: ConvertiblePrimitiveInteger,
@@ -784,9 +939,18 @@ pub fn get_num_molecules_cell_ranger_like_small<B, R, P: EqClassPayload>(
         }
     }
     match sa_model {
-        SplicedAmbiguityModel::WinnerTakeAll => {
-            resolve_num_molecules_crlike_from_vec(&mut umi_gene_count_vec, gene_eqclass_hash);
-        }
+        SplicedAmbiguityModel::WinnerTakeAll => match umi_dedup_mode {
+            UmiDedupMode::Legacy => {
+                resolve_num_molecules_crlike_from_vec(&mut umi_gene_count_vec, gene_eqclass_hash);
+            }
+            UmiDedupMode::CellRanger => {
+                resolve_num_molecules_cellranger_from_vec(
+                    &mut umi_gene_count_vec,
+                    umi_len,
+                    gene_eqclass_hash,
+                );
+            }
+        },
         SplicedAmbiguityModel::PreferAmbiguity => {
             resolve_num_molecules_crlike_from_vec_prefer_ambig(
                 &mut umi_gene_count_vec,
@@ -796,12 +960,15 @@ pub fn get_num_molecules_cell_ranger_like_small<B, R, P: EqClassPayload>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn get_num_molecules_cell_ranger_like<P: EqClassPayload>(
     eq_map: &EqMap,
     tid_to_gid: &[u32],
     _num_genes: usize,
     gene_eqclass_hash: &mut HashMap<Vec<u32>, P, ahash::RandomState>,
     sa_model: SplicedAmbiguityModel,
+    umi_dedup_mode: UmiDedupMode,
+    umi_len: usize,
     _log: &slog::Logger,
 ) {
     // TODO: better capacity
@@ -837,9 +1004,18 @@ pub fn get_num_molecules_cell_ranger_like<P: EqClassPayload>(
         }
     }
     match sa_model {
-        SplicedAmbiguityModel::WinnerTakeAll => {
-            resolve_num_molecules_crlike_from_vec(&mut umi_gene_count_vec, gene_eqclass_hash);
-        }
+        SplicedAmbiguityModel::WinnerTakeAll => match umi_dedup_mode {
+            UmiDedupMode::Legacy => {
+                resolve_num_molecules_crlike_from_vec(&mut umi_gene_count_vec, gene_eqclass_hash);
+            }
+            UmiDedupMode::CellRanger => {
+                resolve_num_molecules_cellranger_from_vec(
+                    &mut umi_gene_count_vec,
+                    umi_len,
+                    gene_eqclass_hash,
+                );
+            }
+        },
         SplicedAmbiguityModel::PreferAmbiguity => {
             resolve_num_molecules_crlike_from_vec_prefer_ambig(
                 &mut umi_gene_count_vec,

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -48,6 +48,7 @@ use crate::em::{
 };
 use crate::eq_class::{EqMap, EqMapType, IndexedEqList};
 use crate::prog_opts::QuantOpts;
+use crate::prog_opts::UmiDedupMode;
 
 /// Shared closure that extracts a sample index from a record.
 type SampleIdxExtractor<R> = Arc<dyn Fn(&R) -> usize + Send + Sync>;
@@ -409,6 +410,8 @@ struct WorkerConfig {
     num_genes: usize,
     num_rows: usize,
     barcode_len: u16,
+    umi_len: u16,
+    umi_dedup_mode: UmiDedupMode,
     /// Cells with fewer than this many records take the tiny-cell fast path.
     /// Set from `--small-thresh`; 0 disables the fast path entirely.
     tiny_cell_thresh: usize,
@@ -857,6 +860,8 @@ where
                                     config.num_genes,
                                     &mut gene_eqc,
                                     config.sa_model,
+                                    config.umi_dedup_mode,
+                                    config.umi_len as usize,
                                     &log,
                                 );
                             } else {
@@ -867,6 +872,8 @@ where
                                     config.num_genes,
                                     &mut gene_eqc,
                                     config.sa_model,
+                                    config.umi_dedup_mode,
+                                    config.umi_len as usize,
                                     &log,
                                 );
                                 eq_map.clear();
@@ -1043,6 +1050,8 @@ where
                         config.num_genes,
                         &mut gene_eqc,
                         config.sa_model,
+                        config.umi_dedup_mode,
+                        config.umi_len as usize,
                         &log,
                     );
                     // USA-mode
@@ -1370,6 +1379,7 @@ where
     let tiny_cell_thresh = quant_opts.small_thresh;
     let large_graph_thresh = quant_opts.large_graph_thresh;
     let filter_list = quant_opts.filter_list;
+    let umi_dedup_mode = quant_opts.umi_dedup_mode;
     let log = quant_opts.log;
     let num_threads = quant_opts.num_threads;
     let num_bootstraps = quant_opts.num_bootstraps;
@@ -1425,6 +1435,21 @@ where
             tid_to_gid = v;
             usa_mode = us;
             if usa_mode {
+                // Cell Ranger's UMI rules are defined over genes. In USA mode a
+                // gene id here also carries a splicing status, so applying the
+                // low-support rule directly would discard every UMI that is
+                // ambiguous between the spliced and unspliced variant of one
+                // gene, which is not what Cell Ranger does with those reads. How
+                // the two should be reconciled is a modelling decision, not
+                // something this flag should make silently.
+                anyhow::ensure!(
+                    umi_dedup_mode != UmiDedupMode::CellRanger,
+                    "--umi-dedup-mode cellranger is not supported in USA mode \
+                     (a 3-column transcript-to-gene map). Cell Ranger's rules are \
+                     defined over genes, while USA-mode gene ids also encode the \
+                     splicing status; reconciling the two is not decided here. Use \
+                     a 2-column transcript-to-gene map, or --umi-dedup-mode legacy."
+                );
                 assert_eq!(
                     num_bootstraps, 0,
                     "currently USA-mode (all-in-one unspliced/spliced/ambiguous) analysis cannot be used with bootstrapping."
@@ -1507,6 +1532,13 @@ where
         })
         .expect("tag map must contain cblen or bNlen for barcode length");
     let barcode_len: u16 = barcode_tag.try_into()?;
+
+    // UMI length, needed by the Cell Ranger UMI collapsing rule to enumerate
+    // the one-substitution neighbours of a packed UMI.
+    let umi_len: u16 = match file_tag_map.get("ulen") {
+        Some(t) => t.try_into()?,
+        None => 0u16,
+    };
 
     // if we have a filter list, extract it here
     let mut retained_bc: Option<HashSet<u64, ahash::RandomState>> = None;
@@ -1727,6 +1759,8 @@ where
             num_genes,
             num_rows,
             barcode_len,
+            umi_len,
+            umi_dedup_mode,
             tiny_cell_thresh,
         };
 
@@ -1871,6 +1905,19 @@ where
     );
     pbar.finish_with_message(pb_msg);
 
+    if umi_dedup_mode == UmiDedupMode::CellRanger {
+        let st = pugutils::cellranger_umi_stats();
+        info!(
+            log,
+            "Cell Ranger UMI rules: saw {} (UMI, gene) pairs; collapsed {} UMIs onto a \
+             Hamming-distance-one neighbour; discarded {} UMIs with no strict top gene, \
+             {} (UMI, gene) pairs dropped in total",
+            st.umi_genes.to_formatted_string(&Locale::en),
+            st.corrected.to_formatted_string(&Locale::en),
+            st.tied_umis.to_formatted_string(&Locale::en),
+            st.dropped.to_formatted_string(&Locale::en)
+        );
+    }
     info!(
         log,
         "processed {} total read records",


### PR DESCRIPTION
## What this changes

Two rules from `lib/rust/tx_annotation/src/mark_dups.rs` at tag `cellranger-10.0.0`, behind `--umi-dedup-mode cellranger`. **The default is `legacy`**, the current behaviour.

**1. UMI collapsing** (`correct_umis`). Within a gene, a UMI moves onto any UMI one substitution away that carries a strictly greater count, or an equal count and a lexicographically greater sequence. Destinations are chosen from the *original* counts in a single pass; corrections are not applied iteratively. alevin-fry's `cr-like` path does not collapse UMIs at all today (only the parsimony modes do, through the PUG graph).

**2. Low support** (`determine_low_support_umigenes`). A UMI keeps only its strict top gene. If two genes tie for the top count, the whole UMI is discarded, top genes included. alevin-fry currently emits an equivalence class containing every tied gene instead ([`pugutils.rs`, the `Ordering::Equal` arm of `resolve_num_molecules_crlike_from_vec`](https://github.com/COMBINE-lab/alevin-fry/blob/master/src/pugutils.rs)).

The corrections are applied in the two stages Cell Ranger uses: one read moved before the low-support decision, the remainder after. That ordering changes which UMI-genes look tied, and Cell Ranger's comment says it is there to preserve Cell Ranger 3 behaviour, so it is reproduced rather than tidied away.

Comparing packed UMIs numerically is the same as comparing sequences lexicographically here: bases are packed two bits at a time with the first base most significant, and `A=0, C=1, G=2, T=3` is already alphabetical. That is noted in the code so nobody has to re-derive it.

## Deliberately rejected in USA mode

`--umi-dedup-mode cellranger` errors out on a 3-column transcript-to-gene map:

```
Error: could not quantify rad file

Caused by:
    --umi-dedup-mode cellranger is not supported in USA mode (a 3-column
    transcript-to-gene map). Cell Ranger's rules are defined over genes, while
    USA-mode gene ids also encode the splicing status; reconciling the two is
    not decided here. Use a 2-column transcript-to-gene map, or
    --umi-dedup-mode legacy.
```

This is not a limitation I ran into and papered over, it is the point. A USA-mode gene id is a (gene, status) pair, so applying the low-support rule to it discards every UMI that is ambiguous between the spliced and unspliced variant of the *same* gene. Cell Ranger does not throw those reads away; alevin-fry resolves them through `--sa-model`. Deciding how the two should meet is a modelling question for the maintainers, and silently answering it inside a dedup patch would be the wrong place.

Measured on a 3-column map before the guard was added, the naive version cost 16.4% of all UMI counts. That is the size of the mistake being avoided.

## Measurements

Toy dataset from the `sample_run` CI job, 2-column transcript-to-gene map, `quant -r cr-like --small-thresh 0`:

| | value |
|---|---|
| (UMI, gene) pairs seen | 19,763,904 |
| UMIs collapsed onto a 1-Hamming neighbour | 517,099 |
| UMIs discarded with no strict top gene | 1,639,024 |
| (UMI, gene) pairs dropped in total | 9,235,405 |

| | `legacy` | `cellranger` |
|---|---|---|
| total UMI counts | 10,505,282 | 10,203,023 (**-2.9%**) |
| nonzeros | 3,593,219 | 3,606,303 (+0.4%) |

Counts fall while nonzeros rise slightly: collapsing merges duplicate UMIs, while the strict-winner rule assigns some UMIs that `legacy` had spread across a multi-gene equivalence class (and that `cr-like` then dropped) to a single gene.

The counters are logged when the mode is on, so a user can see what the rules did rather than only the aggregate:

```
INFO Cell Ranger UMI rules: saw 19,763,904 (UMI, gene) pairs; collapsed 517,099 UMIs
onto a Hamming-distance-one neighbour; discarded 1,639,024 UMIs with no strict top
gene, 9,235,405 (UMI, gene) pairs dropped in total
```

**Default path unchanged**: `legacy` gives 0 of 26,126 cells differing from a master build, on both the 2-column and 3-column maps.

## Drive-by

Two `panic!("could not quantify rad file.")` arms in `main.rs` now return the error with context instead of discarding it. Without that, the USA-mode rejection above surfaces as a bare panic with no explanation. It is a two-line change and I have kept it in this PR because this PR is what makes it matter; say the word and I will split it out.

## Checks

- `cargo test --workspace`: 24 passed, 1 ignored, 0 failed
- `cargo clippy --workspace --all-targets`: clean
- `cargo fmt --check`: clean