### PR TITLE
feat(quant): optionally write the gene-level view of a USA-mode matrix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@
 
 use anyhow::{anyhow, bail};
 use bio_types::strand::Strand;
-use clap::{Command, arg, builder::ArgGroup, crate_authors, crate_version, value_parser};
+use clap::{
+    ArgAction, Command, arg, builder::ArgGroup, crate_authors, crate_version, value_parser,
+};
 use csv::Error as CSVError;
 use csv::ErrorKind;
 use itertools::Itertools;
@@ -217,6 +219,8 @@ fn main() -> anyhow::Result<()> {
         ])
         .default_value("0") // for any other mode
         .hide(true))
+    .arg(arg!(--"usa-collapse" "in USA mode, also write a gene-level matrix summing the spliced, unspliced and ambiguous columns of each gene, which is the shape Cell Ranger produces with intron inclusion on")
+        .action(ArgAction::SetTrue))
     .arg(arg!(--"small-thresh" <SMALLTHRESH> "cells with fewer than this many reads are resolved by a fast path that applies cr-like (winner-take-all) semantics regardless of --resolution; pass 0 to resolve every cell with the requested strategy")
         .value_parser(value_parser!(usize))
         .default_value("100"))
@@ -471,6 +475,7 @@ fn main() -> anyhow::Result<()> {
         let resolution = *t.get_one::<ResolutionStrategy>("resolution").unwrap();
         let sa_model = *t.get_one::<SplicedAmbiguityModel>("sa-model").unwrap();
         let small_thresh = *t.get_one("small-thresh").unwrap();
+        let usa_collapse = t.get_flag("usa-collapse");
         let filter_list: Option<&PathBuf> = t.get_one("quant-subset");
         let large_graph_thresh: usize = *t.get_one("large-graph-thresh").unwrap();
         let umi_edit_dist: u32 = *t.get_one("umi-edit-dist").unwrap();
@@ -570,6 +575,7 @@ fn main() -> anyhow::Result<()> {
             .resolution(resolution)
             .sa_model(sa_model)
             .small_thresh(small_thresh)
+            .usa_collapse(usa_collapse)
             .large_graph_thresh(large_graph_thresh)
             .filter_list(filter_list)
             .pug_exact_umi(pug_exact_umi)

--- a/src/prog_opts.rs
+++ b/src/prog_opts.rs
@@ -35,6 +35,10 @@ pub struct QuantOpts<'a, 'b, 'c, 'd, 'e, 'f, 'g> {
     pub small_thresh: usize,
     pub large_graph_thresh: usize,
     pub filter_list: Option<&'d PathBuf>,
+    /// In USA mode, also write a gene-level matrix summing each gene's
+    /// spliced, unspliced and ambiguous columns.
+    #[builder(default = false)]
+    pub usa_collapse: bool,
     pub cmdline: &'e str,
     pub version: &'f str,
     #[serde(skip_serializing)]

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -1370,6 +1370,7 @@ where
     let tiny_cell_thresh = quant_opts.small_thresh;
     let large_graph_thresh = quant_opts.large_graph_thresh;
     let filter_list = quant_opts.filter_list;
+    let usa_collapse = quant_opts.usa_collapse;
     let log = quant_opts.log;
     let num_threads = quant_opts.num_threads;
     let num_bootstraps = quant_opts.num_bootstraps;
@@ -1778,7 +1779,7 @@ where
 
     // if we are not using unspliced then just write the gene names
     if !usa_mode {
-        for g in gene_names {
+        for g in gene_names.iter() {
             gn_writer.write_all(format!("{}\n", g).as_bytes())?;
         }
     } else {
@@ -1834,6 +1835,62 @@ where
 
     let mtx_path = output_matrix_path.join("quants_mat.mtx");
     sprs::io::write_matrix_market(mtx_path, &trimat)?;
+
+    // Optionally also emit the gene-level view of a USA-mode matrix.
+    //
+    // Cell Ranger, with intron inclusion on (the default since 7.0), reports one
+    // count per gene: a UMI counts toward its gene whether the reads behind it
+    // were exonic, intronic or both. USA mode splits exactly that number three
+    // ways, since a UMI lands in precisely one of the spliced, unspliced or
+    // ambiguous columns of its gene. Summing the three recovers Cell Ranger's
+    // shape, and the sum is the same number of molecules, not an approximation.
+    //
+    // The columns are laid out as [S | U | A], each `num_genes` wide, so gene
+    // `g` is columns `g`, `g + num_genes` and `g + 2 * num_genes`. Writing it
+    // here rather than leaving it to the user is the point: getting that offset
+    // wrong is silent.
+    //
+    // The USA matrix is still written; this is an extra file, not a replacement.
+    if usa_mode && usa_collapse {
+        let mut collapsed: HashMap<(usize, usize), f32, ahash::RandomState> =
+            HashMap::with_capacity_and_hasher(
+                trimat.nnz(),
+                ahash::RandomState::with_seeds(2u64, 7u64, 1u64, 8u64),
+            );
+        for (val, (row, col)) in trimat.triplet_iter() {
+            let (row, col) = (row as usize, col as usize);
+            *collapsed.entry((row, col % num_genes)).or_insert(0.0) += *val;
+        }
+
+        let mut gene_trimat = sprs::TriMatI::<f32, u32>::with_capacity(
+            (num_cells as usize, num_genes),
+            collapsed.len(),
+        );
+        // sorted so the file does not depend on hash iteration order
+        let mut entries: Vec<((usize, usize), f32)> = collapsed.into_iter().collect();
+        entries.sort_unstable_by_key(|&((r, c), _)| (r, c));
+        for ((row, col), val) in entries {
+            gene_trimat.add_triplet(row, col, val);
+        }
+
+        let gene_mtx_path = output_matrix_path.join("quants_mat_gene.mtx");
+        sprs::io::write_matrix_market(gene_mtx_path, &gene_trimat)?;
+
+        let gene_cols_path = output_matrix_path.join("quants_mat_gene_cols.txt");
+        let gene_cols_file =
+            File::create(gene_cols_path).expect("couldn't create gene-level column name file.");
+        let mut gene_cols_writer = BufWriter::new(gene_cols_file);
+        for g in gene_names.iter() {
+            gene_cols_writer.write_all(format!("{}\n", *g).as_bytes())?;
+        }
+
+        info!(
+            log,
+            "wrote the gene-level (Cell Ranger shaped) matrix with {} genes and {} nonzeros",
+            num_genes.to_formatted_string(&Locale::en),
+            gene_trimat.nnz().to_formatted_string(&Locale::en)
+        );
+    }
 
     // Write bootstrap summary stat matrices if bootstraps were computed
     if num_bootstraps > 0 && !all_boot_mean_triplets.is_empty() {


### PR DESCRIPTION
## What

`--usa-collapse` writes `quants_mat_gene.mtx` and `quants_mat_gene_cols.txt` next to the USA matrix, summing each gene's spliced, unspliced and ambiguous columns. Off by default, and additive: the USA matrix is still written.

## Why this is the intron-counting item

Cell Ranger with intron inclusion on (the default since 7.0) reports one count per gene. A UMI counts toward its gene whether the reads behind it were exonic, intronic, or both; there is no per-status breakdown in `filtered_feature_bc_matrix`.

USA mode splits exactly that number three ways. A UMI lands in precisely one of a gene's spliced, unspliced or ambiguous columns, so summing the three is not an approximation of Cell Ranger's number, it *is* that number under alevin-fry's resolution. Confirmed on the toy dataset: the USA matrix and the collapsed matrix both total 10,954,363 counts.

The part that does not belong in alevin-fry is the assignment itself. Whether a read is exonic or intronic is decided by the index (splici / spliceu) and the mapper, upstream of the RAD file. There is nothing here to align with Cell Ranger on that; what was missing was the last step, and it is one that users currently do by hand in R or Python.

Doing it in-tool is worth the flag because the layout is easy to get wrong and wrong silently: columns are `[S | U | A]`, each `num_genes` wide, so gene `g` is at `g`, `g + num_genes` and `g + 2 * num_genes`. A reader who assumes interleaved columns gets a plausible-looking matrix of nonsense.

## Measurements

Toy dataset, `quant -r cr-like --small-thresh 0 --usa-collapse`:

| | dims | nonzeros | total counts |
|---|---|---|---|
| `quants_mat.mtx` (USA) | 26,126 x 236,697 | 4,332,929 | 10,954,363 |
| `quants_mat_gene.mtx` | 26,126 x 78,899 | 3,737,170 | 10,954,363 |

Totals match exactly, as they must. Recollapsing the USA matrix independently in Python reproduces the written file with zero mismatching entries.

Without the flag, output is unchanged: `0 of 26,126` cells differ from a master build, and no extra files appear.

Entries are sorted before writing, so the file does not depend on hash iteration order. (Worth stating given that this pipeline's outputs are otherwise not byte-stable run to run: see #171.)

## Checks

- `cargo test --workspace`: 24 passed, 1 ignored, 0 failed
- `cargo clippy --workspace --all-targets`: clean
- `cargo fmt --check`: clean