### PR TITLE
Deterministic shared barcode correction for RNA and Flex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 [[package]]
 name = "libradicl"
 version = "0.17.0"
-source = "git+https://github.com/COMBINE-lab/libradicl.git?rev=194d127105f22acbc1d9731c68022d610cc5ca86#194d127105f22acbc1d9731c68022d610cc5ca86"
+source = "git+https://github.com/COMBINE-lab/libradicl.git?rev=195cd1d81b87bc291e677103aa5ebe84984782cf#195cd1d81b87bc291e677103aa5ebe84984782cf"
 dependencies = [
  "ahash",
  "anyhow",
@@ -898,7 +898,7 @@ dependencies = [
 [[package]]
 name = "libradicl-macros"
 version = "0.17.0"
-source = "git+https://github.com/COMBINE-lab/libradicl.git?rev=194d127105f22acbc1d9731c68022d610cc5ca86#194d127105f22acbc1d9731c68022d610cc5ca86"
+source = "git+https://github.com/COMBINE-lab/libradicl.git?rev=195cd1d81b87bc291e677103aa5ebe84984782cf#195cd1d81b87bc291e677103aa5ebe84984782cf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ keywords = [
 categories = ["command-line-utilities", "science"]
 
 [dependencies]
-libradicl = { version = "0.17.0", git = "https://github.com/COMBINE-lab/libradicl.git", rev = "194d127105f22acbc1d9731c68022d610cc5ca86" }
+libradicl = { version = "0.17.0", git = "https://github.com/COMBINE-lab/libradicl.git", rev = "195cd1d81b87bc291e677103aa5ebe84984782cf" }
 anyhow = "1.0.102"
 arrayvec = "0.7.6"
 ahash = "0.8.12"

--- a/src/barcode_correction.rs
+++ b/src/barcode_correction.rs
@@ -1,0 +1,1185 @@
+/*
+ * Copyright (c) 2020-2024 COMBINE-lab.
+ *
+ * This file is part of alevin-fry
+ * (see https://www.github.com/COMBINE-lab/alevin-fry).
+ *
+ * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
+ */
+
+//! Deterministic barcode-correction policy and compilation.
+//!
+//! This module decides corrections. Consumers such as collation receive the
+//! resulting sorted table and never enumerate neighbours or choose between
+//! competing targets themselves.
+
+use ahash::AHashMap;
+use anyhow::{anyhow, bail};
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::hash::Hash;
+use std::str::FromStr;
+
+/// Which fixed-length, one-error neighbourhood to search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BarcodeNeighborhood {
+    /// One nucleotide substitution (Hamming distance one).
+    HammingOne,
+    /// One substitution or a fixed-length one-base shift.
+    ///
+    /// The shift operations preserve the barcode length by dropping a base at
+    /// one end and admitting any base at the other. This is the historical
+    /// alevin-fry `edit-1` behaviour; it is not general Levenshtein distance.
+    SubstitutionOrShiftOne,
+}
+
+impl fmt::Display for BarcodeNeighborhood {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HammingOne => f.write_str("hamming-1"),
+            Self::SubstitutionOrShiftOne => f.write_str("substitution-or-shift-1"),
+        }
+    }
+}
+
+impl FromStr for BarcodeNeighborhood {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "hamming-1" => Ok(Self::HammingOne),
+            "substitution-or-shift-1" | "edit-1" => Ok(Self::SubstitutionOrShiftOne),
+            _ => bail!(
+                "unknown barcode neighbourhood '{value}'; expected hamming-1 or substitution-or-shift-1"
+            ),
+        }
+    }
+}
+
+/// An exact rational confidence threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Confidence {
+    numerator: u64,
+    denominator: u64,
+}
+
+impl Confidence {
+    pub const RNA: Self = Self {
+        numerator: 39,
+        denominator: 40,
+    };
+    pub const ATAC: Self = Self {
+        numerator: 9,
+        denominator: 10,
+    };
+
+    pub fn new(numerator: u64, denominator: u64) -> anyhow::Result<Self> {
+        if denominator == 0 || numerator > denominator {
+            bail!(
+                "barcode-correction confidence must be between zero and one (got {numerator}/{denominator})"
+            );
+        }
+        let divisor = gcd(numerator, denominator);
+        Ok(Self {
+            numerator: numerator / divisor,
+            denominator: denominator / divisor,
+        })
+    }
+
+    pub fn numerator(self) -> u64 {
+        self.numerator
+    }
+
+    pub fn denominator(self) -> u64 {
+        self.denominator
+    }
+
+    fn accepts(self, winner: u128, total: u128) -> bool {
+        compare_fractions(
+            winner,
+            total,
+            u128::from(self.numerator),
+            u128::from(self.denominator),
+        ) != std::cmp::Ordering::Less
+    }
+}
+
+/// Compare positive rational values without cross-multiplication overflow.
+fn compare_fractions(
+    mut lhs_num: u128,
+    mut lhs_den: u128,
+    mut rhs_num: u128,
+    mut rhs_den: u128,
+) -> std::cmp::Ordering {
+    debug_assert!(lhs_den != 0 && rhs_den != 0);
+    let mut reversed = false;
+    loop {
+        let lhs_integer = lhs_num / lhs_den;
+        let rhs_integer = rhs_num / rhs_den;
+        if lhs_integer != rhs_integer {
+            let ordering = lhs_integer.cmp(&rhs_integer);
+            return if reversed {
+                ordering.reverse()
+            } else {
+                ordering
+            };
+        }
+
+        let lhs_remainder = lhs_num % lhs_den;
+        let rhs_remainder = rhs_num % rhs_den;
+        match (lhs_remainder == 0, rhs_remainder == 0) {
+            (true, true) => return std::cmp::Ordering::Equal,
+            (true, false) => {
+                return if reversed {
+                    std::cmp::Ordering::Greater
+                } else {
+                    std::cmp::Ordering::Less
+                };
+            }
+            (false, true) => {
+                return if reversed {
+                    std::cmp::Ordering::Less
+                } else {
+                    std::cmp::Ordering::Greater
+                };
+            }
+            (false, false) => {
+                lhs_num = lhs_den;
+                lhs_den = lhs_remainder;
+                rhs_num = rhs_den;
+                rhs_den = rhs_remainder;
+                reversed = !reversed;
+            }
+        }
+    }
+}
+
+impl fmt::Display for Confidence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.numerator, self.denominator)
+    }
+}
+
+impl FromStr for Confidence {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let value = value.trim();
+        if let Some((numerator, denominator)) = value.split_once('/') {
+            return Self::new(numerator.parse()?, denominator.parse()?);
+        }
+
+        let (whole, fractional) = value.split_once('.').unwrap_or((value, ""));
+        if whole.is_empty() || !whole.bytes().all(|b| b.is_ascii_digit()) {
+            bail!("invalid barcode-correction confidence '{value}'");
+        }
+        if !fractional.bytes().all(|b| b.is_ascii_digit()) || fractional.len() > 18 {
+            bail!("invalid barcode-correction confidence '{value}'");
+        }
+        let denominator = 10u64
+            .checked_pow(fractional.len() as u32)
+            .ok_or_else(|| anyhow!("barcode-correction confidence is too precise"))?;
+        let whole: u64 = whole.parse()?;
+        let fractional: u64 = if fractional.is_empty() {
+            0
+        } else {
+            fractional.parse()?
+        };
+        let numerator = whole
+            .checked_mul(denominator)
+            .and_then(|v| v.checked_add(fractional))
+            .ok_or_else(|| anyhow!("barcode-correction confidence is too large"))?;
+        Self::new(numerator, denominator)
+    }
+}
+
+const fn gcd(mut lhs: u64, mut rhs: u64) -> u64 {
+    while rhs != 0 {
+        let remainder = lhs % rhs;
+        lhs = rhs;
+        rhs = remainder;
+    }
+    if lhs == 0 { 1 } else { lhs }
+}
+
+/// How collisions between distinct canonical targets are resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BarcodeResolution {
+    /// Accept only one distinct canonical target.
+    Unique,
+    /// Use frozen exact-source counts as priors.
+    Frequency {
+        confidence: Confidence,
+        pseudocount: u64,
+    },
+}
+
+/// Complete, resolved correction policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorrectionSpec {
+    pub barcode_len: u8,
+    pub neighborhood: BarcodeNeighborhood,
+    pub resolution: BarcodeResolution,
+}
+
+impl CorrectionSpec {
+    pub fn validate(self) -> anyhow::Result<Self> {
+        if !(1..=32).contains(&self.barcode_len) {
+            bail!(
+                "barcode length must be between 1 and 32 (got {})",
+                self.barcode_len
+            );
+        }
+        if let BarcodeResolution::Frequency { pseudocount, .. } = self.resolution
+            && pseudocount == 0
+        {
+            bail!("frequency correction requires a non-zero pseudocount");
+        }
+        Ok(self)
+    }
+}
+
+/// A permitted source barcode, its canonical target, and its frozen raw count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetainedSource<T> {
+    pub source: u64,
+    pub target: T,
+    pub exact_count: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct IndexedSource<T> {
+    target: T,
+    exact_count: u64,
+}
+
+/// The deterministic result for one observed barcode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CorrectionDecision<T> {
+    Exact(T),
+    Corrected(T),
+    Ambiguous,
+    NotFound,
+}
+
+impl<T> CorrectionDecision<T> {
+    pub fn target(self) -> Option<T> {
+        match self {
+            Self::Exact(target) | Self::Corrected(target) => Some(target),
+            Self::Ambiguous | Self::NotFound => None,
+        }
+    }
+}
+
+/// Counts for both distinct observed barcodes and the reads they represent.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorrectionStats {
+    pub exact_distinct: u64,
+    pub exact_reads: u64,
+    pub corrected_distinct: u64,
+    pub corrected_reads: u64,
+    pub ambiguous_distinct: u64,
+    pub ambiguous_reads: u64,
+    pub not_found_distinct: u64,
+    pub not_found_reads: u64,
+}
+
+/// A sorted, accepted observed-to-canonical correction table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorrectionTable<T> {
+    entries: Vec<(u64, T)>,
+    stats: CorrectionStats,
+}
+
+/// A compiled, policy-free view of the complete one-error topology.
+///
+/// Accepted entries have exactly one distinct canonical target. Barcodes in
+/// `ambiguous` have more than one structurally possible target. Both vectors
+/// are sorted, which lets callers choose an execution lookup without exposing
+/// one from the correction engine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructuralCorrectionTable<T> {
+    entries: Vec<(u64, T)>,
+    ambiguous: Vec<u64>,
+}
+
+impl<T> StructuralCorrectionTable<T> {
+    pub fn entries(&self) -> &[(u64, T)] {
+        &self.entries
+    }
+
+    pub fn ambiguous(&self) -> &[u64] {
+        &self.ambiguous
+    }
+}
+
+impl<T> CorrectionTable<T> {
+    pub fn entries(&self) -> &[(u64, T)] {
+        &self.entries
+    }
+
+    pub fn into_entries(self) -> Vec<(u64, T)> {
+        self.entries
+    }
+
+    pub fn stats(&self) -> CorrectionStats {
+        self.stats
+    }
+}
+
+/// An index of retained sources used to resolve and compile corrections.
+///
+/// Its concrete hash table and hasher are private so callers depend only on
+/// deterministic correction semantics, not an implementation detail.
+#[derive(Debug, Clone)]
+pub struct CorrectionIndex<T> {
+    spec: CorrectionSpec,
+    /// Retained sources sorted by packed barcode. The prefix offsets keep
+    /// one-substitution candidate lookups in small contiguous slices without
+    /// exposing or depending on a particular hasher.
+    sources: Vec<(u64, IndexedSource<T>)>,
+    source_offsets: Vec<usize>,
+    source_suffix_bits: u8,
+}
+
+impl<T> CorrectionIndex<T>
+where
+    T: Copy + Eq + Ord + Hash,
+{
+    pub fn new<I>(spec: CorrectionSpec, sources: I) -> anyhow::Result<Self>
+    where
+        I: IntoIterator<Item = RetainedSource<T>>,
+    {
+        let spec = spec.validate()?;
+        let mut retained_sources: Vec<_> = sources.into_iter().collect();
+        retained_sources.sort_unstable_by_key(|retained| retained.source);
+        let mut index: Vec<(u64, IndexedSource<T>)> = Vec::with_capacity(retained_sources.len());
+        for retained in retained_sources {
+            validate_barcode(retained.source, spec.barcode_len)?;
+            match index.last() {
+                Some((source, previous))
+                    if *source == retained.source && previous.target != retained.target =>
+                {
+                    bail!(
+                        "retained source barcode {} was assigned conflicting canonical targets",
+                        retained.source
+                    )
+                }
+                Some((source, previous))
+                    if *source == retained.source
+                        && previous.exact_count != retained.exact_count =>
+                {
+                    bail!(
+                        "retained source barcode {} was assigned conflicting exact counts",
+                        retained.source
+                    )
+                }
+                Some((source, _)) if *source == retained.source => {}
+                None => {
+                    index.push((
+                        retained.source,
+                        IndexedSource {
+                            target: retained.target,
+                            exact_count: retained.exact_count,
+                        },
+                    ));
+                }
+                Some(_) => index.push((
+                    retained.source,
+                    IndexedSource {
+                        target: retained.target,
+                        exact_count: retained.exact_count,
+                    },
+                )),
+            }
+        }
+        // Cap the prefix at eight bases (65,536 slots). This preserves the
+        // narrow lookup ranges used for ordinary 16-base cell barcodes while
+        // remaining safe for any supported barcode length through 32.
+        let source_prefix_len = spec.barcode_len.div_ceil(2).min(8);
+        let source_suffix_bits = 2 * (spec.barcode_len - source_prefix_len);
+        let prefix_count = 1usize << (2 * source_prefix_len);
+        let mut source_offsets = vec![0; prefix_count + 1];
+        let mut cursor = 0usize;
+        for (prefix, offset) in source_offsets.iter_mut().enumerate() {
+            while cursor < index.len() && (index[cursor].0 >> source_suffix_bits) < prefix as u64 {
+                cursor += 1;
+            }
+            *offset = cursor;
+        }
+        Ok(Self {
+            spec,
+            sources: index,
+            source_offsets,
+            source_suffix_bits,
+        })
+    }
+
+    pub fn spec(&self) -> CorrectionSpec {
+        self.spec
+    }
+
+    /// Resolve one barcode according to the configured policy.
+    pub fn resolve(&self, observed: u64) -> CorrectionDecision<T> {
+        if let Some(source) = self.source_for(observed) {
+            return CorrectionDecision::Exact(source.target);
+        }
+
+        if self.spec.resolution == BarcodeResolution::Unique {
+            return self.unique_neighbor_target(observed);
+        }
+
+        let candidates = self.candidate_sources(observed);
+        if candidates.is_empty() {
+            return CorrectionDecision::NotFound;
+        }
+
+        let mut targets: SmallVec<[(T, u128); 8]> = SmallVec::new();
+        for source_barcode in candidates {
+            let source = self
+                .source_for(source_barcode)
+                .expect("candidate source is retained");
+            if let Some((_, weight)) = targets
+                .iter_mut()
+                .find(|(target, _)| *target == source.target)
+            {
+                *weight += u128::from(source.exact_count) + u128::from(self.pseudocount());
+            } else {
+                targets.push((
+                    source.target,
+                    u128::from(source.exact_count) + u128::from(self.pseudocount()),
+                ));
+            }
+        }
+
+        let BarcodeResolution::Frequency { confidence, .. } = self.spec.resolution else {
+            unreachable!("Unique correction returned through its allocation-free path")
+        };
+        let total = targets.iter().map(|(_, weight)| *weight).sum();
+        // Use the greatest target as the deterministic final tie-break,
+        // preserving the tuple-max behaviour of the precursor policy.
+        let (winner, winner_weight) = targets
+            .into_iter()
+            .max_by(|lhs, rhs| lhs.1.cmp(&rhs.1).then_with(|| lhs.0.cmp(&rhs.0)))
+            .expect("candidate target list is non-empty");
+        if confidence.accepts(winner_weight, total) {
+            CorrectionDecision::Corrected(winner)
+        } else {
+            CorrectionDecision::Ambiguous
+        }
+    }
+
+    /// Resolve only the candidate topology, without applying an abundance
+    /// policy. This is used by sample-Frequency routing to defer only pairs
+    /// having more than one structurally possible canonical sample.
+    pub fn structural_resolution(&self, observed: u64) -> CorrectionDecision<T> {
+        if let Some(source) = self.source_for(observed) {
+            return CorrectionDecision::Exact(source.target);
+        }
+        self.unique_neighbor_target(observed)
+    }
+
+    /// Compile decisions for observed barcode counts. Retained identities are
+    /// always included, even when their observed count is zero.
+    pub fn compile_observed<I>(&self, observations: I) -> CorrectionTable<T>
+    where
+        I: IntoIterator<Item = (u64, u64)>,
+    {
+        let mut observed_counts = BTreeMap::<u64, u64>::new();
+        for (barcode, count) in observations {
+            let entry = observed_counts.entry(barcode).or_default();
+            *entry = entry
+                .checked_add(count)
+                .expect("observed barcode count overflow");
+        }
+        for &(source, _) in &self.sources {
+            observed_counts.entry(source).or_default();
+        }
+
+        let mut entries = Vec::with_capacity(observed_counts.len());
+        let mut stats = CorrectionStats::default();
+        for (barcode, count) in observed_counts {
+            match self.resolve(barcode) {
+                CorrectionDecision::Exact(target) => {
+                    entries.push((barcode, target));
+                    stats.exact_distinct += 1;
+                    stats.exact_reads += count;
+                }
+                CorrectionDecision::Corrected(target) => {
+                    entries.push((barcode, target));
+                    stats.corrected_distinct += 1;
+                    stats.corrected_reads += count;
+                }
+                CorrectionDecision::Ambiguous => {
+                    stats.ambiguous_distinct += 1;
+                    stats.ambiguous_reads += count;
+                }
+                CorrectionDecision::NotFound => {
+                    stats.not_found_distinct += 1;
+                    stats.not_found_reads += count;
+                }
+            }
+        }
+        CorrectionTable { entries, stats }
+    }
+
+    /// Compile a histogram whose observed barcodes are already distinct while
+    /// aggregating accepted read counts by canonical target in the same pass.
+    ///
+    /// GPL's raw histograms satisfy this stronger contract. Keeping this path
+    /// separate from [`Self::compile_observed`] avoids rebuilding a large,
+    /// already-distinct hash histogram as a tree and avoids a second accepted
+    /// lookup table solely for frequency aggregation. The returned target
+    /// counts are sorted, so the correction engine still does not expose its
+    /// private hash-table implementation.
+    pub(crate) fn compile_distinct_observed_with_target_counts<I>(
+        &self,
+        observations: I,
+    ) -> (CorrectionTable<T>, Vec<(T, u64)>)
+    where
+        I: IntoIterator<Item = (u64, u64)>,
+    {
+        let observations = observations.into_iter();
+        let mut entries = Vec::with_capacity(observations.size_hint().0);
+        let mut target_counts = AHashMap::<T, u64>::new();
+        let mut stats = CorrectionStats::default();
+
+        for (barcode, count) in observations {
+            let target = match self.resolve(barcode) {
+                CorrectionDecision::Exact(target) => {
+                    stats.exact_distinct += 1;
+                    stats.exact_reads += count;
+                    Some(target)
+                }
+                CorrectionDecision::Corrected(target) => {
+                    stats.corrected_distinct += 1;
+                    stats.corrected_reads += count;
+                    Some(target)
+                }
+                CorrectionDecision::Ambiguous => {
+                    stats.ambiguous_distinct += 1;
+                    stats.ambiguous_reads += count;
+                    None
+                }
+                CorrectionDecision::NotFound => {
+                    stats.not_found_distinct += 1;
+                    stats.not_found_reads += count;
+                    None
+                }
+            };
+            if let Some(target) = target {
+                entries.push((barcode, target));
+                let target_count = target_counts.entry(target).or_default();
+                *target_count = target_count
+                    .checked_add(count)
+                    .expect("corrected target count overflow");
+            }
+        }
+
+        entries.sort_unstable_by_key(|&(barcode, _)| barcode);
+        let mut missing_sources = Vec::new();
+        for &(source, indexed) in &self.sources {
+            if entries
+                .binary_search_by_key(&source, |&(barcode, _)| barcode)
+                .is_err()
+            {
+                missing_sources.push((source, indexed.target));
+                stats.exact_distinct += 1;
+            }
+        }
+        if !missing_sources.is_empty() {
+            entries.extend(missing_sources);
+            entries.sort_unstable_by_key(|&(barcode, _)| barcode);
+        }
+        debug_assert!(entries.windows(2).all(|pair| pair[0].0 != pair[1].0));
+
+        let mut target_counts: Vec<_> = target_counts.into_iter().collect();
+        target_counts.sort_unstable_by_key(|&(target, _)| target);
+        (CorrectionTable { entries, stats }, target_counts)
+    }
+
+    /// Compile the complete theoretical one-error map used by historical
+    /// `permit_map.bin` consumers.
+    pub fn compile_full_neighborhood(&self) -> CorrectionTable<T> {
+        let observed = self.theoretical_observations();
+        self.compile_observed(observed.into_iter().map(|barcode| (barcode, 0)))
+    }
+
+    /// Compile all structurally reachable observations before applying a
+    /// collision policy. This is useful when a one-pass caller must route
+    /// exact/unique observations immediately and defer only ambiguous ones.
+    pub fn compile_structural_neighborhood(&self) -> StructuralCorrectionTable<T> {
+        let observed = self.theoretical_observations();
+        let mut entries = Vec::with_capacity(observed.len());
+        let mut ambiguous = Vec::new();
+        for barcode in observed {
+            match self.structural_resolution(barcode) {
+                CorrectionDecision::Exact(target) | CorrectionDecision::Corrected(target) => {
+                    entries.push((barcode, target));
+                }
+                CorrectionDecision::Ambiguous => ambiguous.push(barcode),
+                CorrectionDecision::NotFound => {}
+            }
+        }
+        StructuralCorrectionTable { entries, ambiguous }
+    }
+
+    fn theoretical_observations(&self) -> Vec<u64> {
+        let candidates_per_source = 1 + 3 * usize::from(self.spec.barcode_len) + 8;
+        let mut observed = Vec::with_capacity(self.sources.len() * candidates_per_source);
+        for &(source, _) in &self.sources {
+            observed.push(source);
+            for_each_neighbor(
+                source,
+                self.spec.barcode_len,
+                self.spec.neighborhood,
+                |neighbor| observed.push(neighbor),
+            );
+        }
+        observed.sort_unstable();
+        observed.dedup();
+        observed
+    }
+
+    fn pseudocount(&self) -> u64 {
+        match self.spec.resolution {
+            BarcodeResolution::Unique => 0,
+            BarcodeResolution::Frequency { pseudocount, .. } => pseudocount,
+        }
+    }
+
+    /// Find whether all neighbouring retained sources agree on one canonical
+    /// target. Repeated constructions and aliases of that same target are
+    /// harmless, so Unique and topology-only routing need no candidate vector,
+    /// sort, or deduplication.
+    fn unique_neighbor_target(&self, observed: u64) -> CorrectionDecision<T> {
+        let mut target = None;
+        let mut ambiguous = false;
+        for_each_substitution(observed, self.spec.barcode_len, |source_barcode| {
+            if !ambiguous && let Some(source) = self.source_for(source_barcode) {
+                ambiguous = merge_unique_target(&mut target, source.target);
+            }
+        });
+        if !ambiguous && self.spec.neighborhood == BarcodeNeighborhood::SubstitutionOrShiftOne {
+            for_each_inverse_shift_candidate(observed, self.spec.barcode_len, |source_barcode| {
+                if !ambiguous && let Some(source) = self.source_for(source_barcode) {
+                    ambiguous = merge_unique_target(&mut target, source.target);
+                }
+            });
+        }
+
+        if ambiguous {
+            CorrectionDecision::Ambiguous
+        } else if let Some(target) = target {
+            CorrectionDecision::Corrected(target)
+        } else {
+            CorrectionDecision::NotFound
+        }
+    }
+
+    fn candidate_sources(&self, observed: u64) -> SmallVec<[u64; 128]> {
+        let mut candidates = SmallVec::<[u64; 128]>::new();
+        for_each_substitution(observed, self.spec.barcode_len, |candidate| {
+            if self.source_for(candidate).is_some() {
+                candidates.push(candidate);
+            }
+        });
+        if self.spec.neighborhood == BarcodeNeighborhood::SubstitutionOrShiftOne {
+            for_each_inverse_shift_candidate(observed, self.spec.barcode_len, |source| {
+                if self.source_for(source).is_some() {
+                    candidates.push(source);
+                }
+            });
+        }
+        // Shift candidates can repeat, especially for homopolymers. A source
+        // prior must contribute once regardless of how many constructions
+        // lead to it.
+        candidates.sort_unstable();
+        candidates.dedup();
+        candidates
+    }
+
+    #[inline]
+    fn source_for(&self, barcode: u64) -> Option<IndexedSource<T>> {
+        let prefix = usize::try_from(barcode >> self.source_suffix_bits).ok()?;
+        if prefix + 1 >= self.source_offsets.len() {
+            return None;
+        }
+        let start = self.source_offsets[prefix];
+        let end = self.source_offsets[prefix + 1];
+        self.sources[start..end]
+            .binary_search_by_key(&barcode, |&(source, _)| source)
+            .ok()
+            .map(|index| self.sources[start + index].1)
+    }
+}
+
+fn merge_unique_target<T: Copy + Eq>(target: &mut Option<T>, candidate: T) -> bool {
+    match *target {
+        Some(previous) => previous != candidate,
+        None => {
+            *target = Some(candidate);
+            false
+        }
+    }
+}
+
+fn validate_barcode(barcode: u64, barcode_len: u8) -> anyhow::Result<()> {
+    if barcode_len < 32 && barcode >= (1u64 << (2 * barcode_len)) {
+        bail!("packed barcode {barcode} does not fit declared length {barcode_len}");
+    }
+    Ok(())
+}
+
+fn for_each_neighbor(
+    barcode: u64,
+    barcode_len: u8,
+    neighborhood: BarcodeNeighborhood,
+    mut visit: impl FnMut(u64),
+) {
+    for_each_substitution(barcode, barcode_len, &mut visit);
+    if neighborhood == BarcodeNeighborhood::SubstitutionOrShiftOne {
+        for_each_shift_neighbor(barcode, barcode_len, visit);
+    }
+}
+
+fn for_each_substitution(barcode: u64, barcode_len: u8, mut visit: impl FnMut(u64)) {
+    for position in 0..usize::from(barcode_len) {
+        let shift = 2 * position;
+        let mask = 3u64 << shift;
+        let observed_base = (barcode & mask) >> shift;
+        let cleared = barcode & !mask;
+        for replacement in 0..4u64 {
+            if replacement != observed_base {
+                visit(cleared | (replacement << shift));
+            }
+        }
+    }
+}
+
+fn for_each_shift_neighbor(barcode: u64, barcode_len: u8, mut visit: impl FnMut(u64)) {
+    // Historical fixed-length insertion/deletion constructions. Each pair is
+    // a shift with an arbitrary admitted terminal base.
+    for boundary in 1..usize::from(barcode_len) {
+        let lower_mask = (1u64 << (2 * boundary)) - 1;
+        let upper = barcode & !lower_mask;
+        let lower = barcode & lower_mask;
+        for admitted in 0..4u64 {
+            let insertion = upper | (admitted << (2 * (boundary - 1))) | (lower >> 2);
+            let deletion = upper | admitted | ((lower & !(3u64 << (2 * boundary))) << 2);
+            if insertion != barcode {
+                visit(insertion);
+            }
+            if deletion != barcode {
+                visit(deletion);
+            }
+        }
+    }
+}
+
+/// Enumerate retained sources which would generate `observed` under the
+/// historical directed shift construction above. Computing the inverse per
+/// observation avoids materializing O(retained * barcode_len) reverse pairs.
+fn for_each_inverse_shift_candidate(observed: u64, barcode_len: u8, mut visit: impl FnMut(u64)) {
+    for boundary in 1..usize::from(barcode_len) {
+        let lower_mask = packed_base_mask(boundary);
+        let lower_without_terminal = packed_base_mask(boundary - 1);
+
+        // Inverse of `insertion`: the observed low (boundary - 1) bases
+        // determine source bases 1..boundary, while source base 0 is free.
+        let insertion_fixed = (observed & !lower_mask) | ((observed & lower_without_terminal) << 2);
+        for terminal in 0..4u64 {
+            visit(insertion_fixed | terminal);
+        }
+
+        // Inverse of historical `deletion`. Its OR at the boundary means the
+        // two contributing source bases must be enumerated explicitly.
+        let above_boundary_mask = !packed_base_mask(boundary + 1);
+        let deletion_fixed =
+            (observed & above_boundary_mask) | ((observed >> 2) & lower_without_terminal);
+        let observed_boundary = (observed >> (2 * boundary)) & 3;
+        for lower in 0..4u64 {
+            for upper in 0..4u64 {
+                if lower | upper == observed_boundary {
+                    visit(
+                        deletion_fixed
+                            | (lower << (2 * (boundary - 1)))
+                            | (upper << (2 * boundary)),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn packed_base_mask(num_bases: usize) -> u64 {
+    if num_bases == 32 {
+        u64::MAX
+    } else {
+        (1u64 << (2 * num_bases)) - 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn spec(neighborhood: BarcodeNeighborhood, resolution: BarcodeResolution) -> CorrectionSpec {
+        CorrectionSpec {
+            barcode_len: 2,
+            neighborhood,
+            resolution,
+        }
+    }
+
+    #[test]
+    fn confidence_parsing_is_exact_and_reduced() {
+        assert_eq!("0.975".parse::<Confidence>().unwrap(), Confidence::RNA);
+        assert_eq!("90/100".parse::<Confidence>().unwrap(), Confidence::ATAC);
+        assert!("1.01".parse::<Confidence>().is_err());
+        assert!("NaN".parse::<Confidence>().is_err());
+        assert_eq!(
+            compare_fractions(u128::MAX - 1, u128::MAX, 39, 40),
+            std::cmp::Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn exact_sources_win_over_neighbor_collisions() {
+        let index = CorrectionIndex::new(
+            spec(BarcodeNeighborhood::HammingOne, BarcodeResolution::Unique),
+            [
+                RetainedSource {
+                    source: 0,
+                    target: 10,
+                    exact_count: 1,
+                },
+                RetainedSource {
+                    source: 1,
+                    target: 11,
+                    exact_count: 1,
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(index.resolve(0), CorrectionDecision::Exact(10));
+    }
+
+    #[test]
+    fn unique_counts_distinct_canonical_targets() {
+        let index = CorrectionIndex::new(
+            spec(BarcodeNeighborhood::HammingOne, BarcodeResolution::Unique),
+            [
+                RetainedSource {
+                    source: 1,
+                    target: 7,
+                    exact_count: 4,
+                },
+                RetainedSource {
+                    source: 2,
+                    target: 7,
+                    exact_count: 5,
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(index.resolve(0), CorrectionDecision::Corrected(7));
+    }
+
+    #[test]
+    fn unique_rejects_multiple_targets_independent_of_input_order() {
+        let retained = [
+            RetainedSource {
+                source: 1,
+                target: 10,
+                exact_count: 1,
+            },
+            RetainedSource {
+                source: 2,
+                target: 20,
+                exact_count: 1,
+            },
+        ];
+        let forward = CorrectionIndex::new(
+            spec(BarcodeNeighborhood::HammingOne, BarcodeResolution::Unique),
+            retained,
+        )
+        .unwrap();
+        let reverse = CorrectionIndex::new(
+            spec(BarcodeNeighborhood::HammingOne, BarcodeResolution::Unique),
+            retained.into_iter().rev(),
+        )
+        .unwrap();
+        assert_eq!(forward.resolve(0), CorrectionDecision::Ambiguous);
+        assert_eq!(forward.resolve(0), reverse.resolve(0));
+    }
+
+    #[test]
+    fn structural_compilation_separates_unique_and_ambiguous_routes() {
+        let index = CorrectionIndex::new(
+            CorrectionSpec {
+                barcode_len: 1,
+                neighborhood: BarcodeNeighborhood::HammingOne,
+                resolution: BarcodeResolution::Frequency {
+                    confidence: Confidence::RNA,
+                    pseudocount: 1,
+                },
+            },
+            [
+                RetainedSource {
+                    source: 0,
+                    target: 10,
+                    exact_count: 100,
+                },
+                RetainedSource {
+                    source: 2,
+                    target: 20,
+                    exact_count: 1,
+                },
+            ],
+        )
+        .unwrap();
+        let topology = index.compile_structural_neighborhood();
+        assert_eq!(topology.entries(), &[(0, 10), (2, 20)]);
+        assert_eq!(topology.ambiguous(), &[1, 3]);
+        // The structural table deliberately remains policy-free even though
+        // Frequency can accept the high-prior target for an ambiguous source.
+        assert_eq!(index.resolve(1), CorrectionDecision::Corrected(10));
+    }
+
+    #[test]
+    fn frequency_sums_alias_weights_and_uses_exact_threshold() {
+        let resolution = BarcodeResolution::Frequency {
+            confidence: Confidence::RNA,
+            pseudocount: 1,
+        };
+        let accepted = CorrectionIndex::new(
+            spec(BarcodeNeighborhood::HammingOne, resolution),
+            [
+                RetainedSource {
+                    source: 1,
+                    target: 10,
+                    exact_count: 19,
+                },
+                RetainedSource {
+                    source: 2,
+                    target: 10,
+                    exact_count: 18,
+                },
+                RetainedSource {
+                    source: 3,
+                    target: 20,
+                    exact_count: 0,
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(accepted.resolve(0), CorrectionDecision::Corrected(10));
+
+        let rejected = CorrectionIndex::new(
+            spec(BarcodeNeighborhood::HammingOne, resolution),
+            [
+                RetainedSource {
+                    source: 1,
+                    target: 10,
+                    exact_count: 37,
+                },
+                RetainedSource {
+                    source: 2,
+                    target: 20,
+                    exact_count: 1,
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(rejected.resolve(0), CorrectionDecision::Ambiguous);
+    }
+
+    #[test]
+    fn frequency_tie_break_is_deterministic_but_still_subject_to_confidence() {
+        let index = CorrectionIndex::new(
+            spec(
+                BarcodeNeighborhood::HammingOne,
+                BarcodeResolution::Frequency {
+                    confidence: Confidence::new(1, 2).unwrap(),
+                    pseudocount: 1,
+                },
+            ),
+            [
+                RetainedSource {
+                    source: 1,
+                    target: 10,
+                    exact_count: 0,
+                },
+                RetainedSource {
+                    source: 2,
+                    target: 20,
+                    exact_count: 0,
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(index.resolve(0), CorrectionDecision::Corrected(20));
+    }
+
+    #[test]
+    fn shift_candidates_are_deduplicated_before_scoring() {
+        // Both shift construction directions can produce the same source for
+        // repetitive barcodes; it must contribute its prior only once.
+        let index = CorrectionIndex::new(
+            spec(
+                BarcodeNeighborhood::SubstitutionOrShiftOne,
+                BarcodeResolution::Unique,
+            ),
+            [RetainedSource {
+                source: 5,
+                target: 9,
+                exact_count: 0,
+            }],
+        )
+        .unwrap();
+        assert_eq!(index.resolve(1), CorrectionDecision::Corrected(9));
+    }
+
+    #[test]
+    fn observed_compilation_is_sorted_and_aggregates_stats() {
+        let index = CorrectionIndex::new(
+            spec(BarcodeNeighborhood::HammingOne, BarcodeResolution::Unique),
+            [RetainedSource {
+                source: 1,
+                target: 1,
+                exact_count: 4,
+            }],
+        )
+        .unwrap();
+        let table = index.compile_observed([(8, 3), (0, 2), (0, 4), (1, 4)]);
+        assert_eq!(table.entries(), &[(0, 1), (1, 1)]);
+        assert_eq!(table.stats().exact_reads, 4);
+        assert_eq!(table.stats().corrected_reads, 6);
+        assert_eq!(table.stats().not_found_reads, 3);
+    }
+
+    #[test]
+    fn distinct_compilation_adds_unobserved_retained_identities() {
+        let index = CorrectionIndex::new(
+            spec(BarcodeNeighborhood::HammingOne, BarcodeResolution::Unique),
+            [RetainedSource {
+                source: 1,
+                target: 7,
+                exact_count: 0,
+            }],
+        )
+        .unwrap();
+        let (table, target_counts) = index.compile_distinct_observed_with_target_counts([(8, 3)]);
+        assert_eq!(table.entries(), &[(1, 7)]);
+        assert_eq!(table.stats().exact_distinct, 1);
+        assert_eq!(table.stats().exact_reads, 0);
+        assert_eq!(table.stats().not_found_reads, 3);
+        assert!(target_counts.is_empty());
+    }
+
+    #[test]
+    fn all_supported_lengths_validate_without_shift_overflow() {
+        for barcode_len in 1..=32 {
+            let index = CorrectionIndex::new(
+                CorrectionSpec {
+                    barcode_len,
+                    neighborhood: BarcodeNeighborhood::SubstitutionOrShiftOne,
+                    resolution: BarcodeResolution::Unique,
+                },
+                [RetainedSource {
+                    source: u64::MAX >> (64 - 2 * usize::from(barcode_len)),
+                    target: 1,
+                    exact_count: 0,
+                }],
+            )
+            .unwrap();
+            let _ = index.resolve(0);
+        }
+    }
+
+    #[test]
+    fn shift_neighborhood_matches_the_historical_construction() {
+        for barcode_len in [1usize, 2, 8, 16, 31] {
+            let mask = (1u64 << (2 * barcode_len)) - 1;
+            for barcode in [0, mask, mask / 3, mask / 5] {
+                let expected: HashSet<_> = crate::utils::get_all_snps(barcode, barcode_len)
+                    .into_iter()
+                    .chain(crate::utils::get_all_indels(barcode, barcode_len))
+                    .collect();
+                let mut actual = HashSet::new();
+                for_each_neighbor(
+                    barcode,
+                    barcode_len as u8,
+                    BarcodeNeighborhood::SubstitutionOrShiftOne,
+                    |neighbor| {
+                        actual.insert(neighbor);
+                    },
+                );
+                assert_eq!(actual, expected, "length {barcode_len}, barcode {barcode}");
+            }
+        }
+    }
+
+    #[test]
+    fn inverse_shift_candidates_match_the_directed_forward_relation() {
+        for barcode_len in 1u8..=4 {
+            let universe = 1u64 << (2 * barcode_len);
+            for observed in 0..universe {
+                let mut expected = HashSet::new();
+                for source in 0..universe {
+                    for_each_shift_neighbor(source, barcode_len, |generated| {
+                        if generated == observed {
+                            expected.insert(source);
+                        }
+                    });
+                }
+                let mut actual = HashSet::new();
+                for_each_inverse_shift_candidate(observed, barcode_len, |source| {
+                    if source != observed {
+                        actual.insert(source);
+                    }
+                });
+                assert_eq!(
+                    actual, expected,
+                    "length {barcode_len}, observed {observed}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn directed_shift_lookup_preserves_historical_source_to_observation_semantics() {
+        let spec = CorrectionSpec {
+            barcode_len: 3,
+            neighborhood: BarcodeNeighborhood::SubstitutionOrShiftOne,
+            resolution: BarcodeResolution::Unique,
+        };
+        let forward = CorrectionIndex::new(
+            spec,
+            [RetainedSource {
+                source: 1,
+                target: 1,
+                exact_count: 0,
+            }],
+        )
+        .unwrap();
+        assert_eq!(forward.resolve(8), CorrectionDecision::Corrected(1));
+
+        let reverse = CorrectionIndex::new(
+            spec,
+            [RetainedSource {
+                source: 8,
+                target: 8,
+                exact_count: 0,
+            }],
+        )
+        .unwrap();
+        assert_eq!(reverse.resolve(1), CorrectionDecision::NotFound);
+    }
+}

--- a/src/cellfilter.rs
+++ b/src/cellfilter.rs
@@ -7,12 +7,16 @@
  * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
  */
 
+use crate::barcode_correction::{
+    BarcodeResolution, CorrectionDecision, CorrectionIndex, CorrectionSpec, CorrectionStats,
+    RetainedSource,
+};
+use crate::correction_plan::{BarcodeCorrection, CellCorrectionScope, CorrectionPlan};
+use crate::correction_spool::{DeferredPairSpool, SpoolStats};
 use crate::diagnostics;
 use crate::knee_finding;
-use crate::prog_opts::CellBarcodeCorrectionStrategy;
 use crate::prog_opts::GenPermitListOpts;
 use crate::prog_opts::SampleBarcodeOri;
-use crate::prog_opts::SampleCorrectionMode;
 use crate::utils as afutils;
 use crate::utils::KnownRecordType;
 #[allow(unused_imports)]
@@ -22,8 +26,6 @@ use bio_types::strand::Strand;
 use bstr::io::BufReadExt;
 use dashmap::DashMap;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use itertools::Itertools;
-use libradicl::BarcodeLookupMap;
 use libradicl::exit_codes;
 use libradicl::header::{RadHeader, RadPrelude};
 use libradicl::rad_types::{self, RadType, TagMap, TagSection};
@@ -39,8 +41,9 @@ use serde::Serialize;
 use serde_json::json;
 use slog::crit;
 use slog::{info, warn};
-use std::cmp;
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::collections::hash_map::Entry;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::io::{BufWriter, Write};
@@ -102,140 +105,210 @@ fn populate_unfiltered_barcode_map<T: Read>(
     hm
 }
 
-/// What happened to one unmatched cell barcode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CorrectionOutcome {
-    /// Correct it to this retained barcode.
-    Corrected(u64),
-    /// It has neighbours in the retained list, but none of them wins.
-    Ambiguous,
-    /// It has no neighbour in the retained list at all.
-    NotFound,
+type BarcodeCountMap = HashMap<u64, u64, ahash::RandomState>;
+
+fn flush_unmatched_counts(
+    local: &mut [BarcodeCountMap],
+    shared: &[std::sync::Mutex<BarcodeCountMap>],
+) {
+    for (sample_idx, buffer) in local.iter_mut().enumerate() {
+        if buffer.is_empty() {
+            continue;
+        }
+        let mut target = shared[sample_idx].lock().unwrap();
+        for (cell, count) in buffer.drain() {
+            *target.entry(cell).or_insert(0) += count;
+        }
+    }
 }
 
-/// Cell Ranger's 0.975 confidence threshold, represented exactly as 39/40.
-const BARCODE_CONFIDENCE_NUMERATOR: u128 = 39;
-const BARCODE_CONFIDENCE_DENOMINATOR: u128 = 40;
+struct MultiSampleCellOutput {
+    sample_idx: usize,
+    num_cells: u64,
+    info: serde_json::Value,
+    scope: CellCorrectionScope,
+}
 
-/// Capture retained-barcode weights before correcting any unmatched barcode.
-///
-/// Cell Ranger's count prior is explicitly the observed whitelist counts
-/// *prior to correction*. Keeping the weights aligned with `bcmap.barcodes`
-/// both freezes those semantics and replaces a hash-table lookup in the inner
-/// candidate loop with an indexed vector access.
-fn retained_barcode_weights(bcmap: &BarcodeLookupMap, count_for: impl Fn(u64) -> u64) -> Vec<u64> {
-    bcmap
-        .barcodes
+#[allow(clippy::too_many_arguments)]
+fn compile_multi_sample_cell_output(
+    sample_idx: usize,
+    sample_bc: u64,
+    sample_name: &str,
+    cell_hist: DashMap<u64, u64, ahash::RandomState>,
+    unmatched_cells: std::sync::Mutex<BarcodeCountMap>,
+    parent: &Path,
+    cell_spec: CorrectionSpec,
+    filter_method: &CellFilterMethod,
+    min_reads: u64,
+    cell_bc_len: u16,
+    log: &slog::Logger,
+) -> anyhow::Result<MultiSampleCellOutput> {
+    let sample_dir = parent.join(format!("sample_{sample_name}"));
+    std::fs::create_dir_all(&sample_dir)?;
+
+    // Consume the sample histogram rather than retaining the DashMap and a
+    // cloned HashMap simultaneously across the whole experiment.
+    let cell_hist: BarcodeCountMap = cell_hist.into_iter().collect();
+    info!(
+        log,
+        "Sample '{}' (bc=0x{:x}): {} distinct cell barcodes observed",
+        sample_name,
+        sample_bc,
+        cell_hist.len().to_formatted_string(&Locale::en),
+    );
+
+    // Preserve the historical multi-sample output contract: unused samples
+    // have metadata/directories but no empty permit files. The compiled plan
+    // remains total so its empty lookup rejects any such records directly.
+    if cell_hist.is_empty() {
+        warn!(
+            log,
+            "Sample '{}' has no reads — skipping permit list generation", sample_name
+        );
+        return Ok(MultiSampleCellOutput {
+            sample_idx,
+            num_cells: 0,
+            info: serde_json::json!({
+                "name": sample_name,
+                "barcode": format!("0x{:x}", sample_bc),
+                "num_reads": 0_u64,
+                "num_cells": 0_u64,
+                "collatable_reads": 0_u64,
+                "cell_correction": CorrectionStats::default(),
+            }),
+            scope: CellCorrectionScope {
+                sample_barcode: Some(sample_bc),
+                spec: cell_spec,
+                corrections: Vec::new(),
+            },
+        });
+    }
+
+    let mut kept_bcs =
+        select_retained_barcodes(&cell_hist, filter_method, min_reads, cell_bc_len, log);
+    let mut observed_counts = cell_hist;
+    for (barcode, count) in unmatched_cells.into_inner().unwrap() {
+        *observed_counts.entry(barcode).or_insert(0) += count;
+    }
+
+    kept_bcs.sort_unstable();
+    kept_bcs.dedup();
+    // Historically, filtered multi-barcode modes reported only exact reads
+    // assigned to the selected cells in sample_info.json.  Unfiltered mode
+    // already included rescued reads. Keep that field stable while exposing
+    // the complete compiled-correction total separately below.
+    let exact_retained_reads = kept_bcs
         .iter()
-        .map(|&barcode| {
-            count_for(barcode)
-                .checked_add(1)
-                .expect("retained barcode count overflow while applying Laplace smoothing")
-        })
-        .collect()
-}
+        .map(|barcode| observed_counts.get(barcode).copied().unwrap_or(0))
+        .sum::<u64>();
+    info!(
+        log,
+        "  {} retained cell-barcode targets for sample '{}'",
+        kept_bcs.len(),
+        sample_name,
+    );
 
-/// Resolve an unmatched barcode with the Cell Ranger-inspired frequency rule.
-///
-/// Cell Ranger walks every single-substitution neighbour of the observed
-/// barcode, keeps the ones on the whitelist, and scores each candidate by
-///
-/// ```text
-/// likelihood = P(sequencing error at this position | base quality)
-///              * (1 + observed count of the candidate)
-/// ```
-///
-/// then corrects to the best candidate when its share of the summed likelihood
-/// reaches 0.975. The `1 +` is Laplace smoothing.
-///
-/// **The quality term is absent here, and cannot be recovered.** A RAD file
-/// stores the barcode 2-bit packed and does not carry the base qualities that
-/// produced it. Cell Ranger uses a flat `BC_MAX_QV` when qualities are absent;
-/// that common error probability cancels from the ratio, leaving the count
-/// prior implemented here.
-///
-/// The candidate set also differs: Cell Ranger scores against the whole
-/// whitelist, while this function scores against the barcodes alevin-fry has
-/// retained after applying `--min-reads`. It is therefore Cell Ranger-inspired,
-/// not an exact reproduction of Cell Ranger's correction pipeline.
-fn frequency_correct(
-    ubc: u64,
-    barcode_len: usize,
-    bcmap: &BarcodeLookupMap,
-    candidate_weights: &[u64],
-) -> CorrectionOutcome {
-    debug_assert!(barcode_len <= 32);
-    debug_assert_eq!(bcmap.barcodes.len(), candidate_weights.len());
+    let correction_index = CorrectionIndex::new(
+        cell_spec,
+        kept_bcs.iter().map(|&barcode| RetainedSource {
+            source: barcode,
+            target: barcode,
+            exact_count: observed_counts.get(&barcode).copied().unwrap_or(0),
+        }),
+    )?;
+    let (observed_table, target_counts) = correction_index
+        .compile_distinct_observed_with_target_counts(
+            observed_counts
+                .iter()
+                .map(|(&barcode, &count)| (barcode, count)),
+        );
+    let sample_freq_map: BarcodeCountMap = target_counts.into_iter().collect();
 
-    let mut best: Option<(u64, u64)> = None;
-    let mut total_weight = 0u128;
+    // Keep legacy permit_map.bin with its theoretical-neighbour semantics,
+    // while compiling it under the same policy as the compact artifact.
+    let full_table = (!matches!(
+        filter_method,
+        CellFilterMethod::UnfilteredExternalList(_, _)
+    ))
+    .then(|| correction_index.compile_full_neighborhood());
+    let legacy_entries = full_table
+        .as_ref()
+        .map_or(observed_table.entries(), |table| table.entries());
+    let full_permit_list: HashMap<u64, u64> = legacy_entries
+        .iter()
+        .copied()
+        .filter(|(_, target)| sample_freq_map.contains_key(target))
+        .collect();
+    let map_file = File::create(sample_dir.join("permit_map.bin"))?;
+    bincode::serialize_into(BufWriter::new(map_file), &full_permit_list)
+        .map_err(|e| anyhow!("failed to serialize permit map: {}", e))?;
 
-    // Generate substitutions in place. `get_all_snps` returns an allocated
-    // vector, which would otherwise allocate 3 * barcode_len entries for every
-    // distinct unmatched barcode on this hot path.
-    for bit_offset in (0..2 * barcode_len).step_by(2) {
-        let base_mask = 3u64 << bit_offset;
-        let observed_base = (ubc & base_mask) >> bit_offset;
-        let cleared = ubc & !base_mask;
+    let correction_stats = observed_table.stats();
+    info!(
+        log,
+        "  Cell correction for sample '{}': {} exact reads, {} corrected, {} ambiguous, {} without a candidate",
+        sample_name,
+        correction_stats.exact_reads,
+        correction_stats.corrected_reads,
+        correction_stats.ambiguous_reads,
+        correction_stats.not_found_reads,
+    );
 
-        for replacement in 0..4u64 {
-            if replacement == observed_base {
-                continue;
-            }
-            let candidate = cleared | (replacement << bit_offset);
-            let Some(index) = bcmap.find_exact(candidate) else {
-                continue;
-            };
+    let mut accepted_entries = observed_table.into_entries();
+    accepted_entries.retain(|(_, target)| sample_freq_map.contains_key(target));
+    let scope = CellCorrectionScope {
+        sample_barcode: Some(sample_bc),
+        spec: cell_spec,
+        corrections: accepted_entries
+            .into_iter()
+            .map(|(observed, corrected)| BarcodeCorrection {
+                observed,
+                corrected,
+            })
+            .collect(),
+    };
 
-            let corrected = bcmap.barcodes[index];
-            let weight = candidate_weights[index];
-            total_weight += u128::from(weight);
-            // Ties go to the larger packed barcode, matching Cell Ranger's
-            // `max` over `(likelihood, barcode)` pairs.
-            match best {
-                Some(current) if current >= (weight, corrected) => {}
-                _ => best = Some((weight, corrected)),
-            }
-        }
-    }
+    afutils::write_permit_list_freq(
+        &sample_dir.join("permit_freq.bin"),
+        cell_bc_len,
+        &sample_freq_map,
+    )
+    .map_err(|e| {
+        anyhow!(
+            "failed to write permit freq for sample '{}': {}",
+            sample_name,
+            e
+        )
+    })?;
 
-    match best {
-        None => CorrectionOutcome::NotFound,
-        Some((best_weight, corrected))
-            if u128::from(best_weight) * BARCODE_CONFIDENCE_DENOMINATOR
-                >= total_weight * BARCODE_CONFIDENCE_NUMERATOR =>
-        {
-            CorrectionOutcome::Corrected(corrected)
-        }
-        Some(_) => CorrectionOutcome::Ambiguous,
-    }
-}
-
-fn correct_unmatched_cell_barcode(
-    ubc: u64,
-    barcode_len: usize,
-    bcmap: &BarcodeLookupMap,
-    strategy: CellBarcodeCorrectionStrategy,
-    candidate_weights: &[u64],
-) -> CorrectionOutcome {
-    match strategy {
-        CellBarcodeCorrectionStrategy::Unique => match bcmap.find_neighbors(ubc, false) {
-            (Some(index), 1) if bcmap.barcodes[index] != ubc => {
-                CorrectionOutcome::Corrected(bcmap.barcodes[index])
-            }
-            (Some(_), count) if count > 1 => CorrectionOutcome::Ambiguous,
-            _ => CorrectionOutcome::NotFound,
-        },
-        CellBarcodeCorrectionStrategy::Frequency => {
-            frequency_correct(ubc, barcode_len, bcmap, candidate_weights)
-        }
-    }
+    let collatable_reads: u64 = sample_freq_map.values().sum();
+    let historical_num_reads = if matches!(
+        filter_method,
+        CellFilterMethod::UnfilteredExternalList(_, _)
+    ) {
+        collatable_reads
+    } else {
+        exact_retained_reads
+    };
+    Ok(MultiSampleCellOutput {
+        sample_idx,
+        num_cells: sample_freq_map.len() as u64,
+        info: serde_json::json!({
+            "name": sample_name,
+            "barcode": format!("0x{:x}", sample_bc),
+            "num_reads": historical_num_reads,
+            "num_cells": sample_freq_map.len(),
+            "collatable_reads": collatable_reads,
+            "cell_correction": correction_stats,
+        }),
+        scope,
+    })
 }
 
 #[allow(clippy::unnecessary_unwrap, clippy::too_many_arguments)]
 fn process_unfiltered(
     hm: DashMap<u64, u64, ahash::RandomState>,
-    mut unmatched_bc: Vec<u64>,
+    unmatched_bc: HashMap<u64, u64, ahash::RandomState>,
     file_tag_map: &rad_types::TagMap,
     filter_meth: &CellFilterMethod,
     expected_ori: Strand,
@@ -250,8 +323,6 @@ fn process_unfiltered(
     let parent = std::path::Path::new(output_dir);
     std::fs::create_dir_all(parent)
         .with_context(|| format!("couldn't create directory path {}", parent.display()))?;
-
-    // the smallest number of reads we'll allow per barcode
     let min_freq = match filter_meth {
         CellFilterMethod::UnfilteredExternalList(_, min_reads) => {
             info!(log, "minimum num reads for barcode pass = {}", *min_reads);
@@ -261,182 +332,95 @@ fn process_unfiltered(
             unimplemented!();
         }
     };
-
-    // the set of barcodes we'll keep
-    let mut kept_bc = Vec::<u64>::new();
-
-    // iterate over the count map
-    for mut kvp in hm.iter_mut() {
-        // if this satisfies our requirement for the minimum count
-        // then keep this barcode
-        if *kvp.value() >= min_freq {
-            kept_bc.push(*kvp.key());
-        } else {
-            // otherwise, we have to add this barcode's
-            // counts to our unmatched list
-            for _ in 0..*kvp.value() {
-                unmatched_bc.push(*kvp.key());
-            }
-            // and then reset the counter for this barcode to 0
-            *kvp.value_mut() = 0u64;
-        }
-    }
-
-    // drop the absent barcodes from hm
-    hm.retain(|_, &mut v| v > 0);
-
-    // how many we will keep
-    let num_passing = kept_bc.len();
-    info!(
-        log,
-        "num_passing = {}",
-        num_passing.to_formatted_string(&Locale::en)
-    );
-
     let barcode_tag = file_tag_map
         .get("cblen")
         .expect("tag map must contain cblen");
     let barcode_len: u16 = barcode_tag.try_into()?;
 
-    // now, we create a second barcode map with just the barcodes
-    // for cells we will keep / rescue.
-    let bcmap2 = BarcodeLookupMap::new(kept_bc, barcode_len as u32);
+    let mut observed_counts: HashMap<u64, u64, ahash::RandomState> = HashMap::default();
+    let mut kept_barcodes = Vec::new();
+    for entry in &hm {
+        if *entry.value() > 0 {
+            observed_counts.insert(*entry.key(), *entry.value());
+        }
+        if *entry.value() >= min_freq {
+            kept_barcodes.push(*entry.key());
+        }
+    }
+    for (barcode, count) in unmatched_bc {
+        *observed_counts.entry(barcode).or_insert(0) += count;
+    }
+    kept_barcodes.sort_unstable();
+
+    let spec = gpl_opts.cell_correction_spec(barcode_len as u8, false);
+    warn_for_shift_frequency(spec, "cell", log);
+    let correction_index = CorrectionIndex::new(
+        spec,
+        kept_barcodes.iter().map(|&barcode| RetainedSource {
+            source: barcode,
+            target: barcode,
+            exact_count: observed_counts.get(&barcode).copied().unwrap_or(0),
+        }),
+    )?;
     info!(
         log,
         "found {} cells with non-trivial number of reads by exact barcode match",
-        bcmap2.barcodes.len().to_formatted_string(&Locale::en)
+        kept_barcodes.len().to_formatted_string(&Locale::en)
     );
 
-    let candidate_weights = match gpl_opts.cell_bc_correction {
-        CellBarcodeCorrectionStrategy::Unique => Vec::new(),
-        CellBarcodeCorrectionStrategy::Frequency => retained_barcode_weights(&bcmap2, |barcode| {
-            hm.get(&barcode).map_or(0, |count| *count)
-        }),
-    };
-
-    // Finally, try to rescue each distinct unmatched barcode according to the
-    // selected strategy. Frequency weights were captured above and remain
-    // fixed even as corrected counts are added to `hm`.
-
-    //let mut found_exact = 0usize;
-    let mut found_approx = 0usize;
-    let mut ambig_approx = 0usize;
-    let mut not_found = 0usize;
-
-    let start_unmatched_time = Instant::now();
-
-    unmatched_bc.sort_unstable();
-
-    let mut distinct_unmatched_bc = 0usize;
-    let mut distinct_recoverable_bc = 0usize;
-
-    // mapping the uncorrected barcode to what it corrects to
-    let mut corrected_list = Vec::<(u64, u64)>::with_capacity(1_000_000);
-
-    for (count, ubc) in unmatched_bc.iter().dedup_with_count() {
-        let resolved = correct_unmatched_cell_barcode(
-            *ubc,
-            barcode_len as usize,
-            &bcmap2,
-            gpl_opts.cell_bc_correction,
-            &candidate_weights,
+    let started = Instant::now();
+    let (correction_table, target_counts) = correction_index
+        .compile_distinct_observed_with_target_counts(
+            observed_counts
+                .iter()
+                .map(|(&barcode, &count)| (barcode, count)),
         );
-
-        match resolved {
-            CorrectionOutcome::Corrected(cbc) => {
-                // then increment the count of this
-                // barcode by 1 (because we'll correct to it)
-                if let Some(mut c) = hm.get_mut(&cbc) {
-                    *c += count as u64;
-                    corrected_list.push((*ubc, cbc));
-                }
-                // this counts as an approximate find
-                found_approx += count;
-                distinct_recoverable_bc += 1;
-            }
-            CorrectionOutcome::Ambiguous => {
-                ambig_approx += count;
-            }
-            CorrectionOutcome::NotFound => {
-                not_found += count;
-            }
-        }
-        distinct_unmatched_bc += 1;
-    }
-    let unmatched_duration = start_unmatched_time.elapsed();
-    let num_corrected = distinct_recoverable_bc as u64;
-
+    let permitted_map: HashMap<u64, u64, ahash::RandomState> = target_counts.into_iter().collect();
+    let stats = correction_table.stats();
     info!(
         log,
-        "There were {} distinct unmatched barcodes, and {} that can be recovered",
-        distinct_unmatched_bc.to_formatted_string(&Locale::en),
-        distinct_recoverable_bc.to_formatted_string(&Locale::en)
-    );
-    info!(
-        log,
-        "Matching unmatched barcodes to retained barcodes took {:?}", unmatched_duration
-    );
-    info!(log, "Of the unmatched barcodes\n============");
-    info!(
-        log,
-        "\t{} were corrected to a retained barcode under the '{}' strategy",
-        found_approx.to_formatted_string(&Locale::en),
-        gpl_opts.cell_bc_correction,
-    );
-    info!(
-        log,
-        "\t{} remained ambiguous under the '{}' strategy",
-        ambig_approx.to_formatted_string(&Locale::en),
-        gpl_opts.cell_bc_correction,
-    );
-    info!(
-        log,
-        "\t{} had no neighbor in the retained list",
-        not_found.to_formatted_string(&Locale::en)
+        "Cell correction took {:?}: {} exact reads, {} corrected, {} ambiguous, {} without a candidate",
+        started.elapsed(),
+        stats.exact_reads,
+        stats.corrected_reads,
+        stats.ambiguous_reads,
+        stats.not_found_reads,
     );
 
-    let parent = std::path::Path::new(output_dir);
-    std::fs::create_dir_all(parent).with_context(|| {
-        format!(
-            "couldn't create path to output directory {}",
-            parent.display()
-        )
-    })?;
-    let o_path = parent.join("permit_freq.bin");
+    afutils::write_permit_list_freq(&parent.join("permit_freq.bin"), barcode_len, &permitted_map)
+        .map_err(|error| anyhow!("could not write permit frequencies: {error}"))?;
+    let permit_map: HashMap<u64, u64, ahash::RandomState> = correction_table
+        .entries()
+        .iter()
+        .copied()
+        .filter(|(_, target)| permitted_map.contains_key(target))
+        .collect();
+    let pm_file = File::create(parent.join("permit_map.bin"))?;
+    bincode::serialize_into(BufWriter::new(pm_file), &permit_map)
+        .context("couldn't serialize permit list mapping")?;
 
-    // convert the DashMap to a HashMap
-    let mut hm: HashMap<u64, u64, ahash::RandomState> = hm.into_iter().collect();
-    match afutils::write_permit_list_freq(&o_path, barcode_len, &hm) {
-        Ok(_) => {}
-        Err(error) => {
-            panic!("Error: {}", error);
-        }
+    let compact_entries = correction_table
+        .entries()
+        .iter()
+        .copied()
+        .filter(|(_, target)| permitted_map.contains_key(target))
+        .map(|(observed, corrected)| BarcodeCorrection {
+            observed,
+            corrected,
+        })
+        .collect();
+    let mut correction_plan = CorrectionPlan {
+        sample_barcode_len: None,
+        cell_barcode_len: barcode_len as u8,
+        sample_spec: None,
+        sample_corrections: Vec::new(),
+        cell_scopes: vec![CellCorrectionScope {
+            sample_barcode: None,
+            spec,
+            corrections: compact_entries,
+        }],
     };
-
-    /*
-    // don't need this right now
-    let s_path = parent.join("bcmap.bin");
-    let s_file = std::fs::File::create(&s_path).expect("could not create serialization file.");
-    let mut s_writer = BufWriter::new(&s_file);
-    bincode::serialize_into(&mut s_writer, &bcmap2).expect("couldn't serialize barcode list.");
-    */
-
-    // now that we are done with using hm to count, we can repurpose it as
-    // the correction map.
-    for (k, v) in hm.iter_mut() {
-        // each present barcode corrects to itself
-        *v = *k;
-        //*kvp.value_mut() = *kvp.key();
-    }
-    for (uncorrected, corrected) in corrected_list.iter() {
-        hm.insert(*uncorrected, *corrected);
-    }
-
-    let pm_path = parent.join("permit_map.bin");
-    let pm_file = std::fs::File::create(pm_path).context("could not create serialization file.")?;
-    let mut pm_writer = BufWriter::new(&pm_file);
-    bincode::serialize_into(&mut pm_writer, &hm)
-        .context("couldn't serialize permit list mapping.")?;
+    correction_plan.write_to(parent)?;
 
     let meta_info = json!({
     "velo_mode" : velo_mode,
@@ -445,7 +429,10 @@ fn process_unfiltered(
     "max-ambig-record" : max_ambiguity_read,
     "cmd" : cmdline,
     "permit-list-type" : "unfiltered",
-    "gpl_options" : &gpl_opts
+    "gpl_options" : &gpl_opts,
+    "resolved_cell_bc_neighborhood": spec.neighborhood.to_string(),
+    "resolved_cell_bc_confidence": gpl_opts.cell_bc_confidence.to_string(),
+    "correction_stats": stats,
     });
 
     let m_path = parent.join("generate_permit_list.json");
@@ -460,10 +447,10 @@ fn process_unfiltered(
     info!(
         log,
         "total number of distinct corrected barcodes : {}",
-        num_corrected.to_formatted_string(&Locale::en)
+        stats.corrected_distinct.to_formatted_string(&Locale::en)
     );
 
-    Ok(num_corrected)
+    Ok(stats.corrected_distinct)
 }
 
 #[allow(clippy::unnecessary_unwrap, clippy::too_many_arguments)]
@@ -480,80 +467,43 @@ fn process_filtered(
     log: &slog::Logger,
     gpl_opts: &GenPermitListOpts,
 ) -> anyhow::Result<u64> {
-    let valid_bc: Vec<u64>;
     let hm: HashMap<u64, u64, ahash::RandomState> = hm.into_iter().collect();
-    let mut freq: Vec<u64> = hm.values().cloned().collect();
-    freq.sort_unstable();
-    freq.reverse();
-
     let barcode_tag = file_tag_map
         .get("cblen")
         .expect("tag map must contain cblen");
     let barcode_len: u16 = barcode_tag.try_into()?;
+    let mut valid_barcodes = select_retained_barcodes(&hm, filter_meth, 0, barcode_len, log);
+    valid_barcodes.sort_unstable();
+    valid_barcodes.dedup();
+    info!(
+        log,
+        "filtering selected {} retained barcode targets",
+        valid_barcodes.len()
+    );
 
-    // select from among supported filter methods
-    match filter_meth {
-        CellFilterMethod::KneeFinding => {
-            let num_bc = knee_finding::get_knee(&freq[..], 100, log);
-            let min_freq = freq[num_bc];
-
-            // collect all of the barcodes that have a frequency
-            // >= to min_thresh.
-            valid_bc = permit_list_from_threshold(&hm, min_freq);
-            info!(
-                log,
-                "knee distance method resulted in the selection of {} permitted barcodes.",
-                valid_bc.len()
-            );
-        }
-        CellFilterMethod::ForceCells(top_k) => {
-            let num_bc = if freq.len() < *top_k {
-                freq.len() - 1
-            } else {
-                top_k - 1
-            };
-
-            let min_freq = freq[num_bc];
-
-            // collect all of the barcodes that have a frequency
-            // >= to min_thresh.
-            valid_bc = permit_list_from_threshold(&hm, min_freq);
-        }
-        CellFilterMethod::ExplicitList(valid_bc_file) => {
-            valid_bc = permit_list_from_file(valid_bc_file, barcode_len);
-        }
-        CellFilterMethod::ExpectCells(expected_num_cells) => {
-            let robust_quantile = 0.99f64;
-            let robust_div = 10.0f64;
-            let robust_ind = (*expected_num_cells as f64 * robust_quantile).round() as u64;
-            // the robust ind must be valid
-            let ind = cmp::min(freq.len() - 1, robust_ind as usize);
-            let robust_freq = freq[ind];
-            let min_freq = std::cmp::max(1u64, (robust_freq as f64 / robust_div).round() as u64);
-            valid_bc = permit_list_from_threshold(&hm, min_freq);
-        }
-        CellFilterMethod::UnfilteredExternalList(_, _min_reads) => {
-            unimplemented!();
-        }
-    }
-
-    // generate the map from each permitted barcode to all barcodes within
-    // edit distance 1 of it.
-    let full_permit_list =
-        afutils::generate_unambiguous_permitlist_map(&valid_bc, barcode_len as usize)
-            .map_err(|error| anyhow!("failed to generate permit list map: {}", error))?;
-
-    let s2 = ahash::RandomState::with_seeds(2u64, 7u64, 1u64, 8u64);
-    let mut permitted_map = HashMap::with_capacity_and_hasher(valid_bc.len(), s2);
-
-    let mut num_corrected = 0;
-    for (k, v) in hm.iter() {
-        if let Some(&valid_key) = full_permit_list.get(k) {
-            *permitted_map.entry(valid_key).or_insert(0u64) += *v;
-            num_corrected += 1;
-            //println!("{} was a neighbor of {}, with count {}", k, valid_key, v);
-        }
-    }
+    let spec = gpl_opts.cell_correction_spec(barcode_len as u8, false);
+    warn_for_shift_frequency(spec, "cell", log);
+    let correction_index = CorrectionIndex::new(
+        spec,
+        valid_barcodes.iter().map(|&barcode| RetainedSource {
+            source: barcode,
+            target: barcode,
+            exact_count: hm.get(&barcode).copied().unwrap_or(0),
+        }),
+    )?;
+    let (correction_table, target_counts) = correction_index
+        .compile_distinct_observed_with_target_counts(
+            hm.iter().map(|(&barcode, &count)| (barcode, count)),
+        );
+    let permitted_map: HashMap<u64, u64, ahash::RandomState> = target_counts.into_iter().collect();
+    let full_permit_list: HashMap<u64, u64> = correction_index
+        .compile_full_neighborhood()
+        .entries()
+        .iter()
+        .copied()
+        .filter(|(_, target)| permitted_map.contains_key(target))
+        .collect();
+    let stats = correction_table.stats();
 
     let parent = std::path::Path::new(output_dir);
     std::fs::create_dir_all(parent).with_context(|| {
@@ -586,6 +536,29 @@ fn process_filtered(
     bincode::serialize_into(&mut s_writer, &full_permit_list)
         .context("couldn't serialize permit list.")?;
 
+    let compact_entries = correction_table
+        .entries()
+        .iter()
+        .copied()
+        .filter(|(_, target)| permitted_map.contains_key(target))
+        .map(|(observed, corrected)| BarcodeCorrection {
+            observed,
+            corrected,
+        })
+        .collect();
+    let mut correction_plan = CorrectionPlan {
+        sample_barcode_len: None,
+        cell_barcode_len: barcode_len as u8,
+        sample_spec: None,
+        sample_corrections: Vec::new(),
+        cell_scopes: vec![CellCorrectionScope {
+            sample_barcode: None,
+            spec,
+            corrections: compact_entries,
+        }],
+    };
+    correction_plan.write_to(parent)?;
+
     let meta_info = json!({
     "velo_mode" : velo_mode,
     "expected_ori" : *expected_ori.strand_symbol(),
@@ -593,7 +566,10 @@ fn process_filtered(
     "max-ambig-record" : max_ambiguity_read,
     "cmd" : cmdline,
     "permit-list-type" : "filtered",
-    "gpl_options" : &gpl_opts
+    "gpl_options" : &gpl_opts,
+    "resolved_cell_bc_neighborhood": spec.neighborhood.to_string(),
+    "resolved_cell_bc_confidence": gpl_opts.cell_bc_confidence.to_string(),
+    "correction_stats": stats,
     });
 
     let m_path = parent.join("generate_permit_list.json");
@@ -608,10 +584,10 @@ fn process_filtered(
     info!(
         log,
         "total number of distinct corrected barcodes : {}",
-        num_corrected.to_formatted_string(&Locale::en)
+        stats.corrected_distinct.to_formatted_string(&Locale::en)
     );
 
-    Ok(num_corrected)
+    Ok(stats.corrected_distinct)
 }
 
 /// Given the input RAD file `input_file`, compute
@@ -688,6 +664,61 @@ pub fn generate_permit_list(gpl_opts: GenPermitListOpts) -> anyhow::Result<u64> 
     }
 }
 
+fn warn_for_shift_frequency(spec: CorrectionSpec, kind: &str, log: &slog::Logger) {
+    if matches!(spec.resolution, BarcodeResolution::Frequency { .. })
+        && spec.neighborhood
+            == crate::barcode_correction::BarcodeNeighborhood::SubstitutionOrShiftOne
+    {
+        warn!(
+            log,
+            "{}-barcode Frequency correction is using substitution-or-shift-1. RAD stores no barcode base qualities or indel-error model, so this is an abundance heuristic rather than a calibrated indel posterior.",
+            kind
+        );
+    }
+}
+
+fn select_retained_barcodes(
+    histogram: &HashMap<u64, u64, ahash::RandomState>,
+    method: &CellFilterMethod,
+    unfiltered_min_reads: u64,
+    barcode_len: u16,
+    log: &slog::Logger,
+) -> Vec<u64> {
+    if let CellFilterMethod::ExplicitList(path) = method {
+        return permit_list_from_file(path, barcode_len);
+    }
+    if histogram.is_empty() {
+        return Vec::new();
+    }
+
+    let mut frequencies: Vec<u64> = histogram.values().copied().collect();
+    frequencies.sort_unstable_by(|lhs, rhs| rhs.cmp(lhs));
+    let threshold = match method {
+        CellFilterMethod::UnfilteredExternalList(_, _) => unfiltered_min_reads,
+        CellFilterMethod::KneeFinding => {
+            let knee = knee_finding::get_knee(&frequencies, 100, log);
+            frequencies[knee.min(frequencies.len() - 1)]
+        }
+        CellFilterMethod::ForceCells(number) => {
+            if *number == 0 {
+                return Vec::new();
+            }
+            frequencies[number.saturating_sub(1).min(frequencies.len() - 1)]
+        }
+        CellFilterMethod::ExpectCells(expected) => {
+            let robust_index =
+                ((*expected as f64 * 0.99).round() as usize).min(frequencies.len() - 1);
+            std::cmp::max(1, (frequencies[robust_index] as f64 / 10.0).round() as u64)
+        }
+        CellFilterMethod::ExplicitList(_) => unreachable!(),
+    };
+
+    histogram
+        .iter()
+        .filter_map(|(&barcode, &count)| (count >= threshold).then_some(barcode))
+        .collect()
+}
+
 /// Multi-barcode generate-permit-list implementation.
 ///
 /// For protocols like 10x Flex with multiple barcodes per read (e.g., sample + cell):
@@ -727,8 +758,13 @@ fn do_generate_permit_list_multi_bc(
     let sample_info = load_sample_barcode_list(sample_bc_list_path, gpl_opts.sample_bc_ori, log)?;
 
     // Build sample barcode correction map (rotation → canonical)
-    let (sample_permit_map, sample_bc_to_idx) =
-        build_sample_permit_map(&sample_info, &gpl_opts.sample_correction_mode, log)?;
+    let sample_correction_spec = gpl_opts.sample_correction_spec(sample_info.barcode_len as u8);
+    let sample_routing = build_sample_permit_map(&sample_info, sample_correction_spec, log)?;
+    let sample_permit_map = sample_routing.permit_map;
+    let sample_bc_to_idx = sample_routing.canonical_to_index;
+    let ambiguous_sample_barcodes = sample_routing.ambiguous_sample_barcodes;
+    let sample_frequency = sample_correction_spec
+        .is_some_and(|spec| matches!(spec.resolution, BarcodeResolution::Frequency { .. }));
 
     // Get sample names from the barcode file (uses canonical → name mapping)
     let sample_names = get_sample_names(&sample_info);
@@ -769,14 +805,19 @@ fn do_generate_permit_list_multi_bc(
     // Per-sample cell barcode frequency (only whitelist-matching BCs) — thread-safe
     let per_sample_cell_hist: Vec<DashMap<u64, u64, ahash::RandomState>> =
         (0..num_samples).map(|_| DashMap::default()).collect();
-    // Per-sample unmatched cell barcodes (for 1-edit rescue) — per-worker, merged after
-    let per_sample_unmatched: Vec<std::sync::Mutex<Vec<u64>>> = (0..num_samples)
-        .map(|_| std::sync::Mutex::new(Vec::new()))
+    // Per-sample unmatched cell barcode counts. Counts avoid the historical
+    // occurrence-sized vectors while retaining exact read totals.
+    let per_sample_unmatched: Vec<std::sync::Mutex<HashMap<u64, u64, ahash::RandomState>>> = (0
+        ..num_samples)
+        .map(|_| std::sync::Mutex::new(HashMap::default()))
         .collect();
 
     let total_reads = std::sync::atomic::AtomicU64::new(0);
     let matched_reads = std::sync::atomic::AtomicU64::new(0);
     let unmatched_reads = std::sync::atomic::AtomicU64::new(0);
+    let exact_sample_reads = std::sync::atomic::AtomicU64::new(0);
+    let structurally_unique_sample_reads = std::sync::atomic::AtomicU64::new(0);
+    let deferred_sample_reads = std::sync::atomic::AtomicU64::new(0);
 
     let nworkers = gpl_opts.threads.max(1);
     let mut chunk_reader = libradicl::readers::ParallelChunkReader::<MultiBarcodeReadRecord>::new(
@@ -800,98 +841,265 @@ fn do_generate_permit_list_multi_bc(
     let per_sample_unmatched = std::sync::Arc::new(per_sample_unmatched);
     let sample_permit_map = std::sync::Arc::new(sample_permit_map);
     let sample_bc_to_idx = std::sync::Arc::new(sample_bc_to_idx);
+    let ambiguous_sample_barcodes = std::sync::Arc::new(ambiguous_sample_barcodes);
+    let sample_exact_sources = std::sync::Arc::new(sample_info.rotation_to_canonical.clone());
     let cell_bc_whitelist = std::sync::Arc::new(cell_bc_whitelist);
     let total_reads_arc = &total_reads;
     let matched_reads_arc = &matched_reads;
     let unmatched_reads_arc = &unmatched_reads;
+    let tmp_dir = gpl_opts
+        .tmp_dir
+        .clone()
+        .unwrap_or_else(|| output_dir.clone());
+    let spool_pairs_per_worker = if sample_frequency {
+        let bytes = gpl_opts.effective_memory_limit() / nworkers as u64;
+        usize::try_from(bytes / std::mem::size_of::<(u64, u64)>() as u64)
+            .unwrap_or(usize::MAX)
+            .max(1)
+    } else {
+        1
+    };
 
-    std::thread::scope(|s| {
-        // Spawn worker threads
-        let mut handles = Vec::new();
-        for _ in 0..nworkers {
-            let chunks = chunk_reader.chunk_iter();
-            let hist = per_sample_cell_hist.clone();
-            let unmatched = per_sample_unmatched.clone();
-            let spm = sample_permit_map.clone();
-            let s2i = sample_bc_to_idx.clone();
-            let wl = cell_bc_whitelist.clone();
+    let (mut correction_spools, sample_exact_counts) = std::thread::scope(
+        |s| -> anyhow::Result<(Vec<DeferredPairSpool>, BarcodeCountMap)> {
+            // Spawn worker threads
+            let mut handles = Vec::new();
+            for worker in 0..nworkers {
+                let chunks = chunk_reader.chunk_iter();
+                let hist = per_sample_cell_hist.clone();
+                let unmatched = per_sample_unmatched.clone();
+                let spm = sample_permit_map.clone();
+                let s2i = sample_bc_to_idx.clone();
+                let ambiguous_samples = ambiguous_sample_barcodes.clone();
+                let exact_sources = sample_exact_sources.clone();
+                let wl = cell_bc_whitelist.clone();
+                let spool_dir = tmp_dir.clone();
 
-            let handle = s.spawn(move || {
-                let mut local_total = 0u64;
-                let mut local_matched = 0u64;
-                let mut local_unmatched_sample = 0u64;
-                // Per-sample local unmatched buffers to reduce lock contention
-                let num_s = hist.len();
-                let mut local_unmatched_bufs: Vec<Vec<u64>> =
-                    (0..num_s).map(|_| Vec::new()).collect();
+                let handle = s.spawn(move || -> anyhow::Result<_> {
+                    let mut local_total = 0u64;
+                    let mut local_matched = 0u64;
+                    let mut local_unmatched_sample = 0u64;
+                    let mut local_exact_sample = 0u64;
+                    let mut local_structurally_unique_sample = 0u64;
+                    let mut local_deferred_sample = 0u64;
+                    let mut local_sample_exact_counts = BarcodeCountMap::default();
+                    let num_s = hist.len();
+                    let mut local_unmatched_bufs: Vec<BarcodeCountMap> =
+                        (0..num_s).map(|_| HashMap::default()).collect();
+                    let mut local_unmatched_distinct = 0usize;
+                    // Bound per-worker duplicate histograms. Without periodic
+                    // reduction, every worker can retain its own copy of most
+                    // distinct unmatched barcodes until the RAD pass ends.
+                    const UNMATCHED_FLUSH_ENTRIES: usize = 1 << 18;
+                    let mut spool = if sample_frequency {
+                        Some(DeferredPairSpool::new(
+                            &spool_dir,
+                            worker,
+                            spool_pairs_per_worker,
+                        )?)
+                    } else {
+                        None
+                    };
 
-                for meta_chunk in chunks {
-                    for c in meta_chunk.iter() {
-                        for read in &c.reads {
-                            local_total += 1;
+                    for meta_chunk in chunks {
+                        for c in meta_chunk.iter() {
+                            for read in &c.reads {
+                                local_total += 1;
 
-                            if !read.has_alignment_on_strand(expected_ori) {
-                                continue;
-                            }
-
-                            let sample_bc: u64 = read.collation_key_at_level(0);
-                            let cell_bc: u64 = read.collate_key();
-
-                            if let Some(&corrected_sample) = spm.get(&sample_bc) {
-                                if let Some(&sample_idx) = s2i.get(&corrected_sample) {
-                                    local_matched += 1;
-                                    if let Some(ref wl_map) = *wl {
-                                        if wl_map.contains_key(&cell_bc) {
-                                            *hist[sample_idx].entry(cell_bc).or_insert(0) += 1;
-                                        } else {
-                                            local_unmatched_bufs[sample_idx].push(cell_bc);
-                                        }
-                                    } else {
-                                        *hist[sample_idx].entry(cell_bc).or_insert(0) += 1;
-                                    }
+                                if !read.has_alignment_on_strand(expected_ori) {
+                                    continue;
                                 }
-                            } else {
-                                local_unmatched_sample += 1;
+
+                                let sample_bc: u64 = read.collation_key_at_level(0);
+                                let cell_bc: u64 = read.collate_key();
+
+                                if let Some(&corrected_sample) = spm.get(&sample_bc) {
+                                    if exact_sources.contains_key(&sample_bc) {
+                                        if sample_frequency {
+                                            *local_sample_exact_counts
+                                                .entry(sample_bc)
+                                                .or_insert(0) += 1;
+                                        }
+                                        local_exact_sample += 1;
+                                    } else {
+                                        local_structurally_unique_sample += 1;
+                                    }
+                                    if let Some(&sample_idx) = s2i.get(&corrected_sample) {
+                                        local_matched += 1;
+                                        if let Some(ref wl_map) = *wl {
+                                            if wl_map.contains_key(&cell_bc) {
+                                                *hist[sample_idx].entry(cell_bc).or_insert(0) += 1;
+                                            } else {
+                                                match local_unmatched_bufs[sample_idx]
+                                                    .entry(cell_bc)
+                                                {
+                                                    Entry::Occupied(mut entry) => {
+                                                        *entry.get_mut() += 1;
+                                                    }
+                                                    Entry::Vacant(entry) => {
+                                                        entry.insert(1);
+                                                        local_unmatched_distinct += 1;
+                                                    }
+                                                }
+                                                if local_unmatched_distinct
+                                                    >= UNMATCHED_FLUSH_ENTRIES
+                                                {
+                                                    flush_unmatched_counts(
+                                                        &mut local_unmatched_bufs,
+                                                        &unmatched,
+                                                    );
+                                                    local_unmatched_distinct = 0;
+                                                }
+                                            }
+                                        } else {
+                                            *hist[sample_idx].entry(cell_bc).or_insert(0) += 1;
+                                        }
+                                    }
+                                } else if sample_frequency
+                                    && ambiguous_samples
+                                        .as_ref()
+                                        .as_ref()
+                                        .expect("Frequency routing has an ambiguity index")
+                                        .contains(&sample_bc)
+                                {
+                                    spool
+                                        .as_mut()
+                                        .expect("Frequency routing has a spool")
+                                        .push(sample_bc, cell_bc)?;
+                                    local_deferred_sample += 1;
+                                } else {
+                                    local_unmatched_sample += 1;
+                                }
                             }
                         }
                     }
+
+                    flush_unmatched_counts(&mut local_unmatched_bufs, &unmatched);
+
+                    Ok((
+                        local_total,
+                        local_matched,
+                        local_unmatched_sample,
+                        local_exact_sample,
+                        local_structurally_unique_sample,
+                        local_deferred_sample,
+                        local_sample_exact_counts,
+                        spool,
+                    ))
+                });
+                handles.push(handle);
+            }
+
+            // Start the chunk reader (this feeds the queue from the BufReader)
+            let cb = |_new_bytes: u64, new_rec: u64| {
+                pbar.inc(new_rec);
+            };
+            chunk_reader.start(&mut ifile, Some(cb))?;
+
+            // Join workers and aggregate counts
+            let mut spools = Vec::new();
+            let mut exact_counts = BarcodeCountMap::default();
+            for handle in handles {
+                let (lt, lm, lu, le, ls, ld, local_exact_counts, spool) =
+                    handle.join().expect("worker thread panicked")?;
+                total_reads_arc.fetch_add(lt, Ordering::SeqCst);
+                matched_reads_arc.fetch_add(lm, Ordering::SeqCst);
+                unmatched_reads_arc.fetch_add(lu, Ordering::SeqCst);
+                exact_sample_reads.fetch_add(le, Ordering::SeqCst);
+                structurally_unique_sample_reads.fetch_add(ls, Ordering::SeqCst);
+                deferred_sample_reads.fetch_add(ld, Ordering::SeqCst);
+                for (barcode, count) in local_exact_counts {
+                    *exact_counts.entry(barcode).or_insert(0) += count;
                 }
-
-                // Flush local unmatched buffers
-                for (idx, buf) in local_unmatched_bufs.into_iter().enumerate() {
-                    if !buf.is_empty() {
-                        unmatched[idx].lock().unwrap().extend(buf);
-                    }
+                if let Some(spool) = spool {
+                    spools.push(spool);
                 }
-
-                (local_total, local_matched, local_unmatched_sample)
-            });
-            handles.push(handle);
-        }
-
-        // Start the chunk reader (this feeds the queue from the BufReader)
-        let cb = |_new_bytes: u64, new_rec: u64| {
-            pbar.inc(new_rec);
-        };
-        let _ = chunk_reader.start(&mut ifile, Some(cb));
-
-        // Join workers and aggregate counts
-        for handle in handles {
-            let (lt, lm, lu) = handle.join().expect("worker thread panicked");
-            total_reads_arc.fetch_add(lt, Ordering::SeqCst);
-            matched_reads_arc.fetch_add(lm, Ordering::SeqCst);
-            unmatched_reads_arc.fetch_add(lu, Ordering::SeqCst);
-        }
-    });
+            }
+            Ok((spools, exact_counts))
+        },
+    )?;
     pbar.finish_and_clear();
 
     let total_reads = total_reads.load(Ordering::SeqCst);
+
+    let mut sample_permit_map = std::sync::Arc::into_inner(sample_permit_map).unwrap();
+    let sample_bc_to_idx = std::sync::Arc::into_inner(sample_bc_to_idx).unwrap();
+
+    let mut replay_time = std::time::Duration::ZERO;
+    let mut spool_stats = SpoolStats::default();
+    let immediate_rejected_sample_reads = unmatched_reads.load(Ordering::SeqCst);
+    let mut deferred_accepted_sample_reads = 0_u64;
+    let mut deferred_rejected_sample_reads = 0_u64;
+    if let Some(spec) = sample_correction_spec
+        .filter(|spec| matches!(spec.resolution, BarcodeResolution::Frequency { .. }))
+    {
+        let frequency_index = CorrectionIndex::new(
+            spec,
+            sample_info
+                .rotation_to_canonical
+                .iter()
+                .map(|(&source, &target)| RetainedSource {
+                    source,
+                    target,
+                    exact_count: sample_exact_counts.get(&source).copied().unwrap_or(0),
+                }),
+        )?;
+        let table = frequency_index.compile_full_neighborhood();
+        sample_permit_map = table.entries().iter().copied().collect();
+
+        let replay_start = Instant::now();
+        for spool in &mut correction_spools {
+            spool.replay(|raw_sample, cell, count| {
+                match frequency_index.resolve(raw_sample) {
+                    CorrectionDecision::Exact(corrected)
+                    | CorrectionDecision::Corrected(corrected) => {
+                        deferred_accepted_sample_reads += count;
+                        let sample_idx = sample_bc_to_idx[&corrected];
+                        matched_reads.fetch_add(count, Ordering::SeqCst);
+                        if let Some(ref whitelist) = *cell_bc_whitelist {
+                            if whitelist.contains_key(&cell) {
+                                *per_sample_cell_hist[sample_idx].entry(cell).or_insert(0) += count;
+                            } else {
+                                *per_sample_unmatched[sample_idx]
+                                    .lock()
+                                    .unwrap()
+                                    .entry(cell)
+                                    .or_insert(0) += count;
+                            }
+                        } else {
+                            *per_sample_cell_hist[sample_idx].entry(cell).or_insert(0) += count;
+                        }
+                    }
+                    CorrectionDecision::Ambiguous | CorrectionDecision::NotFound => {
+                        deferred_rejected_sample_reads += count;
+                        unmatched_reads.fetch_add(count, Ordering::SeqCst);
+                    }
+                }
+                Ok(())
+            })?;
+            let stats = spool.stats();
+            spool_stats.runs += stats.runs;
+            spool_stats.pairs += stats.pairs;
+            spool_stats.encoded_pairs += stats.encoded_pairs;
+            spool_stats.uncompressed_bytes += stats.uncompressed_bytes;
+            spool_stats.compressed_bytes += stats.compressed_bytes;
+        }
+        replay_time = replay_start.elapsed();
+        info!(
+            log,
+            "Sample-Frequency replay: {} deferred reads in {} runs, {} compressed bytes from {} encoded bytes; replay took {:?}",
+            spool_stats.pairs,
+            spool_stats.runs,
+            spool_stats.compressed_bytes,
+            spool_stats.uncompressed_bytes,
+            replay_time,
+        );
+    }
+
     let matched_reads = matched_reads.load(Ordering::SeqCst);
     let unmatched_reads = unmatched_reads.load(Ordering::SeqCst);
 
     // Unwrap the Arcs (single owner again after threads join)
-    let sample_permit_map = std::sync::Arc::into_inner(sample_permit_map).unwrap();
-    let _sample_bc_to_idx = std::sync::Arc::into_inner(sample_bc_to_idx).unwrap();
     let per_sample_cell_hist = std::sync::Arc::into_inner(per_sample_cell_hist).unwrap();
     let per_sample_unmatched = std::sync::Arc::into_inner(per_sample_unmatched).unwrap();
 
@@ -901,6 +1109,16 @@ fn do_generate_permit_list_multi_bc(
         total_reads.to_formatted_string(&Locale::en),
         matched_reads.to_formatted_string(&Locale::en),
         unmatched_reads.to_formatted_string(&Locale::en),
+    );
+    info!(
+        log,
+        "Sample routing: {} exact, {} structurally unique, {} immediately rejected, {} deferred ({} accepted and {} rejected after replay)",
+        exact_sample_reads.load(Ordering::SeqCst),
+        structurally_unique_sample_reads.load(Ordering::SeqCst),
+        immediate_rejected_sample_reads,
+        deferred_sample_reads.load(Ordering::SeqCst),
+        deferred_accepted_sample_reads,
+        deferred_rejected_sample_reads,
     );
 
     // Create output directory
@@ -922,6 +1140,7 @@ fn do_generate_permit_list_multi_bc(
     // Per-sample: generate cell barcode permit lists
     let mut total_cells: u64 = 0;
     let mut sample_info_entries = Vec::new();
+    let mut cell_correction_scopes = Vec::with_capacity(num_samples);
 
     // Get the cell barcode length from file tags
     let cell_bc_tag = format!("b{}len", num_barcodes - 1);
@@ -930,240 +1149,102 @@ fn do_generate_permit_list_multi_bc(
         .unwrap_or_else(|| panic!("expected '{}' file-level tag", cell_bc_tag))
         .try_into()
         .unwrap_or_else(|_| panic!("couldn't parse '{}' as u16", cell_bc_tag));
+    let cell_spec = gpl_opts.cell_correction_spec(cell_bc_len as u8, true);
+    warn_for_shift_frequency(cell_spec, "cell", log);
+    let cell_correction_start = Instant::now();
 
-    for (sample_idx, sample_bc) in sample_info.canonical_barcodes.iter().enumerate() {
-        let sample_name = &sample_names[sample_idx];
-        let sample_dir = parent.join(format!("sample_{}", sample_name));
-        std::fs::create_dir_all(&sample_dir)?;
-
-        // Convert DashMap to HashMap for this sample
-        let cell_hist: HashMap<u64, u64, ahash::RandomState> = per_sample_cell_hist[sample_idx]
-            .clone()
-            .into_iter()
-            .collect();
-        let num_cells_observed = cell_hist.len();
-
-        info!(
-            log,
-            "Sample '{}' (bc=0x{:x}): {} distinct cell barcodes observed",
-            sample_name,
-            sample_bc,
-            num_cells_observed.to_formatted_string(&Locale::en),
-        );
-
-        if cell_hist.is_empty() {
-            warn!(
-                log,
-                "Sample '{}' has no reads — skipping permit list generation", sample_name
-            );
-            sample_info_entries.push(serde_json::json!({
-                "name": sample_name,
-                "barcode": format!("0x{:x}", sample_bc),
-                "num_reads": 0_u64,
-                "num_cells": 0_u64,
-            }));
-            continue;
-        }
-
-        // Determine which cell BCs to keep, applying the same logic as single-barcode.
-        // For UnfilteredExternalList: keep all whitelist BCs with >= min_reads,
-        // then rescue unmatched BCs via 1-edit correction.
-        let mut kept_bcs: Vec<u64> = Vec::new();
-        let mut sample_freq_map: HashMap<u64, u64, ahash::RandomState> = HashMap::default();
-
-        match &gpl_opts.fmeth {
-            CellFilterMethod::UnfilteredExternalList(_, _) => {
-                // Filter by min_reads: keep whitelist BCs that pass threshold
-                let mut below_threshold_bcs = Vec::new();
-                for (bc, count) in cell_hist.iter() {
-                    if *count >= min_reads {
-                        kept_bcs.push(*bc);
-                        sample_freq_map.insert(*bc, *count);
-                    } else {
-                        // BCs below threshold: add their reads to unmatched for rescue
-                        for _ in 0..*count {
-                            below_threshold_bcs.push(*bc);
-                        }
-                    }
-                }
-
-                info!(
-                    log,
-                    "  {} whitelist BCs pass min_reads={} for sample '{}'",
-                    kept_bcs.len(),
-                    min_reads,
-                    sample_name,
-                );
-
-                // Build BarcodeLookupMap from kept BCs for 1-edit correction
-                let bcmap = BarcodeLookupMap::new(kept_bcs.clone(), cell_bc_len as u32);
-                let candidate_weights = match gpl_opts.cell_bc_correction {
-                    CellBarcodeCorrectionStrategy::Unique => Vec::new(),
-                    CellBarcodeCorrectionStrategy::Frequency => {
-                        retained_barcode_weights(&bcmap, |barcode| {
-                            sample_freq_map.get(&barcode).copied().unwrap_or(0)
-                        })
-                    }
-                };
-
-                // Rescue unmatched cell BCs (not in whitelist) via 1-edit correction
-                let mut unmatched = per_sample_unmatched[sample_idx].lock().unwrap();
-                unmatched.append(&mut below_threshold_bcs);
-                unmatched.sort_unstable();
-
-                let mut found_approx = 0usize;
-                let mut ambig_approx = 0usize;
-                let mut not_found = 0usize;
-                let mut corrected_list = Vec::<(u64, u64)>::new();
-
-                for (count, ubc) in unmatched.iter().dedup_with_count() {
-                    match correct_unmatched_cell_barcode(
-                        *ubc,
-                        usize::from(cell_bc_len),
-                        &bcmap,
-                        gpl_opts.cell_bc_correction,
-                        &candidate_weights,
-                    ) {
-                        CorrectionOutcome::Corrected(corrected) => {
-                            *sample_freq_map.entry(corrected).or_insert(0) += count as u64;
-                            corrected_list.push((*ubc, corrected));
-                            found_approx += count;
-                        }
-                        CorrectionOutcome::Ambiguous => ambig_approx += count,
-                        CorrectionOutcome::NotFound => {
-                            not_found += count;
-                        }
-                    }
-                }
-
-                info!(
-                    log,
-                    "  {} unmatched BCs for sample '{}': {} corrected with '{}', {} ambiguous, {} not found",
-                    unmatched.len(),
-                    sample_name,
-                    found_approx.to_formatted_string(&Locale::en),
-                    gpl_opts.cell_bc_correction,
-                    ambig_approx.to_formatted_string(&Locale::en),
-                    not_found.to_formatted_string(&Locale::en),
-                );
-
-                // Write the corrected_list for this sample
-                let corr_path = sample_dir.join("permit_map.bin");
-                // Build the full permit map: identity for kept + correction for rescued
-                let mut full_permit_list: HashMap<u64, u64> =
-                    HashMap::with_capacity(kept_bcs.len() + corrected_list.len());
-                for &bc in &kept_bcs {
-                    full_permit_list.insert(bc, bc);
-                }
-                for (uncorrected, corrected) in &corrected_list {
-                    full_permit_list.entry(*uncorrected).or_insert(*corrected);
-                }
-                let map_file = File::create(&corr_path)?;
-                bincode::serialize_into(BufWriter::new(map_file), &full_permit_list)
-                    .map_err(|e| anyhow!("failed to serialize permit map: {}", e))?;
-            }
-            CellFilterMethod::KneeFinding => {
-                let mut freq: Vec<u64> = cell_hist.values().copied().collect();
-                freq.sort_unstable();
-                freq.reverse();
-                let knee = knee_finding::get_knee(&freq, 100, log);
-                let threshold = if knee > 0 {
-                    freq[knee.saturating_sub(1)]
-                } else {
-                    0
-                };
-                for (bc, count) in cell_hist.iter() {
-                    if *count >= threshold {
-                        kept_bcs.push(*bc);
-                        sample_freq_map.insert(*bc, *count);
-                    }
-                }
-                info!(
-                    log,
-                    "  Knee at {}, {} cells retained for sample '{}'",
-                    knee,
-                    kept_bcs.len(),
-                    sample_name
-                );
-
-                let full_permit_list =
-                    afutils::generate_unambiguous_permitlist_map(&kept_bcs, cell_bc_len as usize)
-                        .map_err(|e| anyhow!("failed to generate permit list map: {}", e))?;
-                let map_path = sample_dir.join("permit_map.bin");
-                let map_file = File::create(&map_path)?;
-                bincode::serialize_into(BufWriter::new(map_file), &full_permit_list)
-                    .map_err(|e| anyhow!("failed to serialize permit map: {}", e))?;
-            }
-            _ => {
-                // ForceCells, ExpectCells, ExplicitList: use frequency-based selection
-                let mut freq: Vec<u64> = cell_hist.values().copied().collect();
-                freq.sort_unstable();
-                freq.reverse();
-                let num_cells = match &gpl_opts.fmeth {
-                    CellFilterMethod::ForceCells(n) => (*n).min(freq.len()),
-                    CellFilterMethod::ExpectCells(n) => {
-                        let threshold = freq[0] / *n as u64;
-                        let idx = freq
-                            .iter()
-                            .position(|&f| f < threshold)
-                            .unwrap_or(freq.len());
-                        (idx as f64 * 10.0) as usize
-                    }
-                    _ => freq.len(),
-                }
-                .min(freq.len());
-                let threshold = if num_cells > 0 {
-                    freq[num_cells.saturating_sub(1)]
-                } else {
-                    0
-                };
-                for (bc, count) in cell_hist.iter() {
-                    if *count >= threshold {
-                        kept_bcs.push(*bc);
-                        sample_freq_map.insert(*bc, *count);
-                    }
-                }
-                info!(
-                    log,
-                    "  {} cells retained for sample '{}'",
-                    kept_bcs.len(),
-                    sample_name
-                );
-
-                let full_permit_list =
-                    afutils::generate_unambiguous_permitlist_map(&kept_bcs, cell_bc_len as usize)
-                        .map_err(|e| anyhow!("failed to generate permit list map: {}", e))?;
-                let map_path = sample_dir.join("permit_map.bin");
-                let map_file = File::create(&map_path)?;
-                bincode::serialize_into(BufWriter::new(map_file), &full_permit_list)
-                    .map_err(|e| anyhow!("failed to serialize permit map: {}", e))?;
-            }
-        }
-
-        // Write per-sample permit_freq.bin
-        let freq_path = sample_dir.join("permit_freq.bin");
-        afutils::write_permit_list_freq(&freq_path, cell_bc_len, &sample_freq_map).map_err(
-            |e| {
-                anyhow!(
-                    "failed to write permit freq for sample '{}': {}",
-                    sample_name,
-                    e
-                )
-            },
-        )?;
-
-        total_cells += kept_bcs.len() as u64;
-
-        let sample_total_reads: u64 = sample_freq_map.values().sum();
-        sample_info_entries.push(serde_json::json!({
-            "name": sample_name,
-            "barcode": format!("0x{:x}", sample_bc),
-            "num_reads": sample_total_reads,
-            "num_cells": kept_bcs.len(),
-        }));
+    // Sample scopes are independent once exact priors are frozen. Use a small
+    // worker cap: this removes the serial tail without multiplying the large
+    // per-sample histograms by the user's full RAD-reader thread count.
+    let correction_workers = gpl_opts.threads.min(4).min(num_samples).max(1);
+    let mut partitions: Vec<Vec<_>> = (0..correction_workers).map(|_| Vec::new()).collect();
+    for (sample_idx, input) in per_sample_cell_hist
+        .into_iter()
+        .zip(per_sample_unmatched)
+        .enumerate()
+    {
+        partitions[sample_idx % correction_workers].push((sample_idx, input));
     }
 
+    let canonical_barcodes = &sample_info.canonical_barcodes;
+    let sample_names_ref = &sample_names;
+    let filter_method = &gpl_opts.fmeth;
+    let mut sample_outputs = std::thread::scope(|scope| -> anyhow::Result<Vec<_>> {
+        let mut handles = Vec::with_capacity(correction_workers);
+        for partition in partitions {
+            let worker_log = log.clone();
+            let handle = scope.spawn(move || -> anyhow::Result<Vec<_>> {
+                partition
+                    .into_iter()
+                    .map(|(sample_idx, (cell_hist, unmatched_cells))| {
+                        compile_multi_sample_cell_output(
+                            sample_idx,
+                            canonical_barcodes[sample_idx],
+                            &sample_names_ref[sample_idx],
+                            cell_hist,
+                            unmatched_cells,
+                            parent,
+                            cell_spec,
+                            filter_method,
+                            min_reads,
+                            cell_bc_len,
+                            &worker_log,
+                        )
+                    })
+                    .collect()
+            });
+            handles.push(handle);
+        }
+
+        let mut outputs = Vec::with_capacity(num_samples);
+        for handle in handles {
+            outputs.extend(handle.join().expect("cell-correction worker panicked")?);
+        }
+        Ok(outputs)
+    })?;
+    sample_outputs.sort_unstable_by_key(|output| output.sample_idx);
+    for output in sample_outputs {
+        total_cells += output.num_cells;
+        sample_info_entries.push(output.info);
+        cell_correction_scopes.push(output.scope);
+    }
+
+    let cell_correction_time = cell_correction_start.elapsed();
+    let sample_corrections = sample_permit_map
+        .iter()
+        .map(|(&observed, &corrected)| BarcodeCorrection {
+            observed,
+            corrected,
+        })
+        .collect();
+    let mut correction_plan = CorrectionPlan {
+        sample_barcode_len: Some(sample_info.barcode_len as u8),
+        cell_barcode_len: cell_bc_len as u8,
+        sample_spec: sample_correction_spec,
+        sample_corrections,
+        cell_scopes: cell_correction_scopes,
+    };
+    let artifact_write_start = Instant::now();
+    let correction_plan_path = correction_plan.write_to(parent)?;
+    let artifact_write_time = artifact_write_start.elapsed();
+    let correction_plan_bytes = std::fs::metadata(&correction_plan_path)?.len();
+    info!(
+        log,
+        "Compiled cell corrections in {:?}; wrote {}-byte correction plan in {:?}",
+        cell_correction_time,
+        correction_plan_bytes,
+        artifact_write_time,
+    );
+
     // Write sample_info.json
+    let resolved_sample_bc_correction = match gpl_opts.sample_correction_mode {
+        crate::prog_opts::SampleCorrectionMode::Exact => "exact",
+        crate::prog_opts::SampleCorrectionMode::Unique
+        | crate::prog_opts::SampleCorrectionMode::OneEdit => "unique",
+        crate::prog_opts::SampleCorrectionMode::Frequency => "frequency",
+    };
+    let resolved_sample_bc_neighborhood =
+        sample_correction_spec.map(|spec| spec.neighborhood.to_string());
     let sample_info = serde_json::json!({
         "num_samples": num_samples,
         "num_barcodes": num_barcodes,
@@ -1174,6 +1255,27 @@ fn do_generate_permit_list_multi_bc(
         "sample_correction_mode": format!("{:?}", gpl_opts.sample_correction_mode),
         "sample_bc_ori": format!("{:?}", gpl_opts.sample_bc_ori),
         "cell_bc_correction": gpl_opts.cell_bc_correction.to_string(),
+        "cell_bc_neighborhood": cell_spec.neighborhood.to_string(),
+        "cell_bc_confidence": gpl_opts.cell_bc_confidence.to_string(),
+        "sample_bc_correction": resolved_sample_bc_correction,
+        "sample_bc_neighborhood": resolved_sample_bc_neighborhood,
+        "sample_bc_confidence": gpl_opts.sample_bc_confidence.to_string(),
+        "cell_correction_seconds": cell_correction_time.as_secs_f64(),
+        "correction_plan_bytes": correction_plan_bytes,
+        "correction_plan_write_seconds": artifact_write_time.as_secs_f64(),
+        "sample_routing": {
+            "exact": exact_sample_reads.load(Ordering::SeqCst),
+            "structurally_unique": structurally_unique_sample_reads.load(Ordering::SeqCst),
+            "immediate_rejected": immediate_rejected_sample_reads,
+            "deferred": deferred_sample_reads.load(Ordering::SeqCst),
+            "deferred_accepted": deferred_accepted_sample_reads,
+            "deferred_rejected": deferred_rejected_sample_reads,
+            "spill_runs": spool_stats.runs,
+            "spill_pairs_after_run_length_encoding": spool_stats.encoded_pairs,
+            "spill_compressed_bytes": spool_stats.compressed_bytes,
+            "spill_uncompressed_bytes": spool_stats.uncompressed_bytes,
+            "replay_seconds": replay_time.as_secs_f64(),
+        },
         "samples": sample_info_entries,
     });
     let info_path = parent.join("sample_info.json");
@@ -1190,6 +1292,11 @@ fn do_generate_permit_list_multi_bc(
         "multi_barcode": true,
         "num_barcodes": num_barcodes,
         "cell_bc_correction": gpl_opts.cell_bc_correction.to_string(),
+        "cell_bc_neighborhood": cell_spec.neighborhood.to_string(),
+        "cell_bc_confidence": gpl_opts.cell_bc_confidence.to_string(),
+        "sample_bc_correction": resolved_sample_bc_correction,
+        "sample_bc_neighborhood": resolved_sample_bc_neighborhood,
+        "sample_bc_confidence": gpl_opts.sample_bc_confidence.to_string(),
     });
     let gpl_meta_path = parent.join("generate_permit_list.json");
     let gpl_meta_file = File::create(&gpl_meta_path)?;
@@ -1330,11 +1437,33 @@ fn load_sample_barcode_list(
         let obs_packed = pack(observed_seq)?;
         let canon_packed = pack(canonical_seq)?;
 
-        rotation_to_canonical.insert(obs_packed, canon_packed);
-        if !canonical_to_name.contains_key(&canon_packed) {
-            canonical_order.push(canon_packed);
+        match rotation_to_canonical.entry(obs_packed) {
+            Entry::Occupied(entry) if *entry.get() != canon_packed => {
+                bail!(
+                    "sample construction barcode '{}' is assigned to conflicting canonical barcodes",
+                    observed_seq
+                );
+            }
+            Entry::Occupied(_) => {}
+            Entry::Vacant(entry) => {
+                entry.insert(canon_packed);
+            }
         }
-        canonical_to_name.insert(canon_packed, name);
+        match canonical_to_name.entry(canon_packed) {
+            Entry::Occupied(entry) if entry.get() != &name => {
+                bail!(
+                    "canonical sample barcode '{}' is assigned conflicting names '{}' and '{}'",
+                    canonical_seq,
+                    entry.get(),
+                    name
+                );
+            }
+            Entry::Occupied(_) => {}
+            Entry::Vacant(entry) => {
+                canonical_order.push(canon_packed);
+                entry.insert(name);
+            }
+        }
     }
 
     let num_rotations = rotation_to_canonical.len();
@@ -1375,11 +1504,17 @@ fn load_sample_barcode_list(
 /// Returns (permit_map, bc_to_idx) where:
 ///   - permit_map maps every observed rotation barcode to its canonical barcode
 ///   - bc_to_idx maps canonical barcode to sample index
+struct SampleCorrectionRouting {
+    permit_map: HashMap<u64, u64>,
+    canonical_to_index: HashMap<u64, usize>,
+    ambiguous_sample_barcodes: Option<HashSet<u64, ahash::RandomState>>,
+}
+
 fn build_sample_permit_map(
     sample_info: &SampleBarcodeInfo,
-    correction_mode: &SampleCorrectionMode,
+    correction_spec: Option<CorrectionSpec>,
     log: &slog::Logger,
-) -> anyhow::Result<(HashMap<u64, u64>, HashMap<u64, usize>)> {
+) -> anyhow::Result<SampleCorrectionRouting> {
     let mut permit_map: HashMap<u64, u64> = HashMap::new();
     let mut bc_to_idx: HashMap<u64, usize> = HashMap::new();
 
@@ -1393,43 +1528,73 @@ fn build_sample_permit_map(
         bc_to_idx.insert(canon, idx);
     }
 
-    match correction_mode {
-        SampleCorrectionMode::Exact => {
+    match correction_spec {
+        None => {
             info!(
                 log,
                 "Sample barcode correction: exact match ({} rotation entries -> {} canonical samples)",
                 permit_map.len(),
                 bc_to_idx.len(),
             );
+            Ok(SampleCorrectionRouting {
+                permit_map,
+                canonical_to_index: bc_to_idx,
+                ambiguous_sample_barcodes: None,
+            })
         }
-        SampleCorrectionMode::OneEdit => {
-            info!(log, "Sample barcode correction mode: 1-edit distance");
-            // Generate 1-edit neighbors for ALL observed rotation barcodes
-            let all_observed: Vec<u64> =
-                sample_info.rotation_to_canonical.keys().copied().collect();
-            let full_map = afutils::generate_unambiguous_correction_map(
-                &all_observed,
-                sample_info.barcode_len,
-                |observed| sample_info.rotation_to_canonical[&observed],
-            )
-            .map_err(|e| anyhow!("failed to generate sample permit map: {}", e))?;
-            for (raw, canonical) in &full_map {
-                if !permit_map.contains_key(raw) {
-                    permit_map.insert(*raw, *canonical);
-                }
-            }
+        Some(spec) => {
+            let topology_spec = CorrectionSpec {
+                resolution: BarcodeResolution::Unique,
+                ..spec
+            };
+            let topology = CorrectionIndex::new(
+                topology_spec,
+                sample_info
+                    .rotation_to_canonical
+                    .iter()
+                    .map(|(&source, &target)| RetainedSource {
+                        source,
+                        target,
+                        exact_count: 0,
+                    }),
+            )?;
+            let structural = topology.compile_structural_neighborhood();
+            permit_map.extend(structural.entries().iter().copied());
             info!(
                 log,
-                "Built sample permit map with {} entries ({} exact + {} corrected) -> {} canonical samples",
+                "Built deterministic sample correction topology with {} entries using {}",
                 permit_map.len(),
-                sample_info.rotation_to_canonical.len(),
-                permit_map.len() - sample_info.rotation_to_canonical.len(),
-                bc_to_idx.len(),
+                spec.neighborhood,
             );
+            let ambiguous_sample_barcodes = if matches!(
+                spec.resolution,
+                BarcodeResolution::Frequency { .. }
+            ) {
+                let ambiguous = structural.ambiguous().iter().copied().collect();
+                info!(
+                    log,
+                    "{} structurally ambiguous sample barcodes will be deferred until exact sample priors are frozen",
+                    structural.ambiguous().len(),
+                );
+                Some(ambiguous)
+            } else {
+                info!(
+                    log,
+                    "Built sample permit map with {} entries ({} exact + {} corrected) -> {} canonical samples",
+                    permit_map.len(),
+                    sample_info.rotation_to_canonical.len(),
+                    permit_map.len() - sample_info.rotation_to_canonical.len(),
+                    bc_to_idx.len(),
+                );
+                None
+            };
+            Ok(SampleCorrectionRouting {
+                permit_map,
+                canonical_to_index: bc_to_idx,
+                ambiguous_sample_barcodes,
+            })
         }
     }
-
-    Ok((permit_map, bc_to_idx))
 }
 
 /// Get sample names for canonical barcodes.
@@ -1452,7 +1617,7 @@ fn get_sample_names(sample_info: &SampleBarcodeInfo) -> Vec<String> {
 /// the prescribed orientation.
 pub fn update_barcode_hist_unfiltered<B, R>(
     hist: &DashMap<u64, u64, ahash::RandomState>,
-    unmatched_bc: &mut Vec<u64>,
+    unmatched_bc: &mut HashMap<u64, u64, ahash::RandomState>,
     max_ambiguity_read: &mut usize,
     chunk: &chunk::Chunk<R>,
     expected_ori: &Strand,
@@ -1474,7 +1639,7 @@ where
                 Some(mut c) => *c += 1,
                 // otherwise, push this into the unmatched list
                 None => {
-                    unmatched_bc.push(r.collate_key().into());
+                    *unmatched_bc.entry(r.collate_key().into()).or_insert(0) += 1;
                 }
             }
         }
@@ -1493,7 +1658,7 @@ where
                     Some(mut c) => *c += 1,
                     // otherwise, push this into the unmatched list
                     None => {
-                        unmatched_bc.push(r.collate_key().into());
+                        *unmatched_bc.entry(r.collate_key().into()).or_insert(0) += 1;
                     }
                 }
             }
@@ -1510,7 +1675,7 @@ where
                         Some(mut c) => *c += 1,
                         // otherwise, push this into the unmatched list
                         None => {
-                            unmatched_bc.push(r.collate_key().into());
+                            *unmatched_bc.entry(r.collate_key().into()).or_insert(0) += 1;
                         }
                     }
                 }
@@ -1528,7 +1693,7 @@ where
                         Some(mut c) => *c += 1,
                         // otherwise, push this into the unmatched list
                         None => {
-                            unmatched_bc.push(r.collate_key().into());
+                            *unmatched_bc.entry(r.collate_key().into()).or_insert(0) += 1;
                         }
                     }
                 }
@@ -1850,7 +2015,8 @@ where
         max_ambiguity_read,
     );
 
-    check_permit_list_validity(gpl_opts.log, unmatched_bc.len(), num_reads)?;
+    let unmatched_reads = unmatched_bc.values().sum::<u64>() as usize;
+    check_permit_list_validity(gpl_opts.log, unmatched_reads, num_reads)?;
 
     let hmu = Arc::try_unwrap(hmu_arc).map_err(|_| anyhow!("Failed to unwrap Arc"))?;
 
@@ -1933,7 +2099,7 @@ fn parse_chunks_unfiltered<R, B>(
     nworkers: usize,
     expected_ori: &Strand,
     cb: impl Fn(u64, u64) + Send + Sync,
-) -> (usize, usize, Vec<u64>, usize)
+) -> (usize, usize, HashMap<u64, u64, ahash::RandomState>, usize)
 where
     R: MappedRecord + CollatableMappedRecord<B> + KnownSize,
     B: ConvertiblePrimitiveInteger,
@@ -1948,7 +2114,7 @@ where
             let hmu = hmu.clone();
 
             let handle = s.spawn(move || {
-                let mut unmatched_bc = Vec::<u64>::new();
+                let mut unmatched_bc: HashMap<u64, u64, ahash::RandomState> = HashMap::default();
                 let mut max_ambiguity_read = 0usize;
                 let mut num_reads = 0;
                 let mut num_orientation_compat_reads = 0;
@@ -1979,14 +2145,16 @@ where
 
         let mut total_reads = 0;
         let mut total_compat = 0;
-        let mut all_unmatched = Vec::new();
+        let mut all_unmatched: HashMap<u64, u64, ahash::RandomState> = HashMap::default();
         let mut max_ambig = 0;
 
         for handle in handles {
             let (nr, nocr, ubc, mar) = handle.join().expect("The parsing thread panicked");
             total_reads += nr;
             total_compat += nocr;
-            all_unmatched.extend_from_slice(&ubc);
+            for (barcode, count) in ubc {
+                *all_unmatched.entry(barcode).or_insert(0) += count;
+            }
             max_ambig = max_ambig.max(mar);
         }
 
@@ -2415,78 +2583,7 @@ where
 #[cfg(test)]
 mod cell_barcode_correction_tests {
     use super::*;
-
-    #[test]
-    fn unique_strategy_preserves_historical_neighbor_rule() {
-        let retained = BarcodeLookupMap::new(vec![1, 5], 2);
-
-        assert_eq!(
-            correct_unmatched_cell_barcode(
-                0,
-                2,
-                &retained,
-                CellBarcodeCorrectionStrategy::Unique,
-                &[],
-            ),
-            CorrectionOutcome::Corrected(1)
-        );
-
-        let ambiguous = BarcodeLookupMap::new(vec![1, 4], 2);
-        assert_eq!(
-            correct_unmatched_cell_barcode(
-                0,
-                2,
-                &ambiguous,
-                CellBarcodeCorrectionStrategy::Unique,
-                &[],
-            ),
-            CorrectionOutcome::Ambiguous
-        );
-    }
-
-    #[test]
-    fn frequency_strategy_handles_absent_unique_ambiguous_and_threshold_cases() {
-        let absent = BarcodeLookupMap::new(vec![5], 2);
-        assert_eq!(
-            frequency_correct(0, 2, &absent, &[1]),
-            CorrectionOutcome::NotFound
-        );
-
-        let unique = BarcodeLookupMap::new(vec![1], 2);
-        assert_eq!(
-            frequency_correct(0, 2, &unique, &[1]),
-            CorrectionOutcome::Corrected(1)
-        );
-
-        let two_candidates = BarcodeLookupMap::new(vec![1, 4], 2);
-        assert_eq!(
-            frequency_correct(0, 2, &two_candidates, &[38, 2]),
-            CorrectionOutcome::Ambiguous
-        );
-        assert_eq!(
-            frequency_correct(0, 2, &two_candidates, &[39, 1]),
-            CorrectionOutcome::Corrected(1),
-            "the exact 39/40 confidence boundary must be accepted"
-        );
-    }
-
-    #[test]
-    fn frequency_weights_are_aligned_and_frozen_before_correction() {
-        let retained = BarcodeLookupMap::new(vec![4, 1], 2);
-        let mut counts = HashMap::from([(1, 38u64), (4, 0u64)]);
-        let weights = retained_barcode_weights(&retained, |barcode| counts[&barcode]);
-        assert_eq!(retained.barcodes, vec![1, 4]);
-        assert_eq!(weights, vec![39, 1]);
-
-        // Later corrections can update the count map, but must not affect the
-        // Cell Ranger prior captured before correction begins.
-        counts.insert(1, 0);
-        counts.insert(4, 1_000);
-        assert_eq!(
-            frequency_correct(0, 2, &retained, &weights),
-            CorrectionOutcome::Corrected(1)
-        );
-    }
+    use crate::prog_opts::CellBarcodeCorrectionStrategy;
 
     #[test]
     fn correction_strategy_has_stable_metadata_names_and_default() {
@@ -2509,8 +2606,14 @@ mod cell_barcode_correction_tests {
             barcode_len: 2,
         };
         let log = slog::Logger::root(slog::Discard, slog::o!());
-        let (permit_map, sample_indices) =
-            build_sample_permit_map(&sample_info, &SampleCorrectionMode::OneEdit, &log).unwrap();
+        let spec = CorrectionSpec {
+            barcode_len: 2,
+            neighborhood: crate::barcode_correction::BarcodeNeighborhood::SubstitutionOrShiftOne,
+            resolution: BarcodeResolution::Unique,
+        };
+        let routing = build_sample_permit_map(&sample_info, Some(spec), &log).unwrap();
+        let permit_map = routing.permit_map;
+        let sample_indices = routing.canonical_to_index;
 
         assert_eq!(permit_map.get(&0), Some(&0));
         assert_eq!(permit_map.get(&5), Some(&5));
@@ -2523,12 +2626,40 @@ mod cell_barcode_correction_tests {
             canonical_to_name: HashMap::new(),
             barcode_len: 2,
         };
-        let (permit_map, _) = build_sample_permit_map(
-            &rotations_of_one_sample,
-            &SampleCorrectionMode::OneEdit,
-            &log,
-        )
-        .unwrap();
+        let permit_map = build_sample_permit_map(&rotations_of_one_sample, Some(spec), &log)
+            .unwrap()
+            .permit_map;
         assert_eq!(permit_map.get(&1), Some(&9));
+    }
+
+    #[test]
+    fn sample_corrections_are_whitelist_order_invariant_and_conflicts_fail() {
+        let dir = tempfile::tempdir().unwrap();
+        let forward_path = dir.path().join("forward.tsv");
+        let reverse_path = dir.path().join("reverse.tsv");
+        std::fs::write(&forward_path, "AA\tAA\ta\nAC\tAA\ta\nCC\tCC\tb\n").unwrap();
+        std::fs::write(&reverse_path, "CC\tCC\tb\nAC\tAA\ta\nAA\tAA\ta\n").unwrap();
+        let log = slog::Logger::root(slog::Discard, slog::o!());
+        let spec = CorrectionSpec {
+            barcode_len: 2,
+            neighborhood: crate::barcode_correction::BarcodeNeighborhood::HammingOne,
+            resolution: BarcodeResolution::Unique,
+        };
+        let forward =
+            load_sample_barcode_list(&forward_path, SampleBarcodeOri::Forward, &log).unwrap();
+        let reverse =
+            load_sample_barcode_list(&reverse_path, SampleBarcodeOri::Forward, &log).unwrap();
+        assert_eq!(
+            build_sample_permit_map(&forward, Some(spec), &log)
+                .unwrap()
+                .permit_map,
+            build_sample_permit_map(&reverse, Some(spec), &log)
+                .unwrap()
+                .permit_map
+        );
+
+        let conflict_path = dir.path().join("conflict.tsv");
+        std::fs::write(&conflict_path, "AA\tAA\ta\nAA\tCC\tb\n").unwrap();
+        assert!(load_sample_barcode_list(&conflict_path, SampleBarcodeOri::Forward, &log).is_err());
     }
 }

--- a/src/collate.rs
+++ b/src/collate.rs
@@ -7,10 +7,11 @@
  * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
  */
 
+use crate::correction_plan::{CORRECTION_PLAN_FILENAME, CorrectionPlan};
 use ahash::AHashMap;
 use anyhow::{Context, anyhow};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use slog::{crit, debug, info};
+use slog::{crit, debug, info, warn};
 //use anyhow::{anyhow, Result};
 use crate::constants as afconst;
 use crate::utils::InternalVersionInfo;
@@ -52,6 +53,42 @@ use std::thread;
 
 use crate::utils as afutils;
 use crate::utils::KnownRecordType;
+
+fn load_single_corrections(
+    parent: &Path,
+    expected_barcode_len: u8,
+    log: &slog::Logger,
+) -> anyhow::Result<HashMap<u64, u64>> {
+    let compact_path = parent.join(CORRECTION_PLAN_FILENAME);
+    if compact_path.exists() {
+        let plan = CorrectionPlan::read_from(&compact_path)?;
+        if plan.sample_barcode_len.is_some() || plan.cell_barcode_len != expected_barcode_len {
+            return Err(anyhow!(
+                "correction plan does not match this single-barcode RAD input"
+            ));
+        }
+        let scope = plan
+            .cell_scopes
+            .iter()
+            .find(|scope| scope.sample_barcode.is_none())
+            .context("single-barcode correction plan has no global cell scope")?;
+        return Ok(scope
+            .corrections
+            .iter()
+            .map(|entry| (entry.observed, entry.corrected))
+            .collect());
+    }
+
+    warn!(
+        log,
+        "No correction_plan.bin was found; loading legacy permit_map.bin. Rerun generate-permit-list to persist deterministic policy decisions."
+    );
+    let correction_file = File::open(parent.join("permit_map.bin"))
+        .context("could not open legacy permit_map.bin")?;
+    let correction_map: HashMap<u64, u64> = bincode::deserialize_from(correction_file)
+        .context("could not deserialize legacy permit_map.bin")?;
+    Ok(correction_map)
+}
 
 #[allow(clippy::too_many_arguments)]
 pub fn collate<P1, P2>(
@@ -234,7 +271,7 @@ where
 
     // sort this so that we deal with largest cells (by # of reads) first
     // sort in _descending_ order by count.
-    tsv_map.sort_unstable_by_key(|&a: &(u64, u64)| std::cmp::Reverse(a.1));
+    tsv_map.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
 
     collate_with_temp_memory(
         input_dir,
@@ -447,6 +484,7 @@ fn do_collate_single_barcode<P1, P2, A>(
     input_dir: P1,
     rad_dir: P2,
     rec_context: AlevinFryRecordContext,
+    barcode_len: u8,
     prelude: RadPrelude,
     mut br: BufReader<A>,
     end_header_pos: u64,
@@ -496,12 +534,9 @@ where
         File::create(&output_path)?,
     )));
 
-    let correction_file =
-        File::open(parent.join("permit_map.bin")).context("could not open permit_map.bin")?;
-    let correction_map: HashMap<u64, u64> = bincode::deserialize_from(correction_file)
-        .context("could not deserialize permit_map.bin")?;
+    let corrections = load_single_corrections(parent, barcode_len, log)?;
     correct_unmapped_counts(
-        &correction_map,
+        &corrections,
         &rad_parent.join("unmapped_bc_count.bin"),
         parent,
     );
@@ -544,9 +579,8 @@ where
         ));
     }
 
-    let correction_map = correction_map.into_iter().collect::<AHashMap<_, _>>();
-    let plan = Arc::new(SingleBarcodeCollationPlan::new(
-        correction_map,
+    let plan = Arc::new(SingleBarcodeCollationPlan::from_corrections(
+        corrections,
         group_to_bucket,
         bucket_records.len(),
     )?);
@@ -619,6 +653,7 @@ pub fn do_collate_with_temp<
     input_dir: P1,
     rad_dir: P2,
     rec_context: <R as MappedRecord>::ParsingContext,
+    barcode_len: u8,
     prelude: RadPrelude,
     mut br: BufReader<A>,
     end_header_pos: u64,
@@ -736,10 +771,7 @@ where
         .with_context(|| format!("couldn't create directory {}", cfname))?;
     let owriter = Arc::new(Mutex::new(BufWriter::with_capacity(1048576, ofile)));
 
-    // get the correction map
-    let cmfile = std::fs::File::open(parent.join("permit_map.bin"))
-        .context("couldn't open output permit_map.bin file")?;
-    let correct_map: Arc<HashMap<u64, u64>> = Arc::new(bincode::deserialize_from(&cmfile).unwrap());
+    let correct_map = Arc::new(load_single_corrections(parent, barcode_len, log)?);
 
     // NOTE: the assumption of where the unmapped file will be
     // should be robustified
@@ -1258,7 +1290,7 @@ where
     let rec_type = afutils::get_record_type_from_prelude(&prelude, &file_tag_map);
 
     match rec_type {
-        KnownRecordType::RnaLong(_bc_len) => {
+        KnownRecordType::RnaLong(bc_len) => {
             info!(log, "record type is long read single-cell RNA-seq");
             // long-read single cell
             info!(log, "long read single-cell");
@@ -1267,6 +1299,7 @@ where
                 input_dir,
                 &rad_dir,
                 parsing_context,
+                bc_len as u8,
                 prelude,
                 br,
                 end_header_pos,
@@ -1284,7 +1317,7 @@ where
             info!(log, "record type is short read single-cell ATAC-seq");
             anyhow::bail!("To process atac-seq data, you should use the \"atac\" sub-command");
         }
-        KnownRecordType::RnaShortPos(_bc_len) => {
+        KnownRecordType::RnaShortPos(bc_len) => {
             // alevin-fry with positions
             info!(log, "short read single-cell with position");
             let parsing_context = prelude.get_record_context::<AlevinFryRecordContext>()?;
@@ -1294,6 +1327,7 @@ where
                         input_dir,
                         &rad_dir,
                         parsing_context,
+                        bc_len as u8,
                         prelude,
                         br,
                         end_header_pos,
@@ -1315,7 +1349,7 @@ where
                 }
             }
         }
-        KnownRecordType::RnaShort(_bc_len) => {
+        KnownRecordType::RnaShort(bc_len) => {
             info!(log, "short read single-cell without poisition");
             let parsing_context = prelude.get_record_context::<AlevinFryRecordContext>()?;
             match parsing_context.bct {
@@ -1324,6 +1358,7 @@ where
                         input_dir,
                         &rad_dir,
                         parsing_context,
+                        bc_len as u8,
                         prelude,
                         br,
                         end_header_pos,
@@ -1421,9 +1456,18 @@ where
     // (sample_idx, corrected_cell_bc).  The cell barcode occupies the low
     // bits; the sample index is shifted above it.
     let cell_bc_bits = (cell_bc_len * 2) as u64; // 2 bits per nucleotide
-    let cell_bc_mask = (1u64 << cell_bc_bits) - 1;
+    let cell_bc_mask = if cell_bc_bits == 64 {
+        u64::MAX
+    } else {
+        (1u64 << cell_bc_bits) - 1
+    };
     let make_composite_key = |sample_idx: u64, cell_bc: u64| -> u64 {
-        (sample_idx << cell_bc_bits) | (cell_bc & cell_bc_mask)
+        if cell_bc_bits == 64 {
+            debug_assert_eq!(sample_idx, 0);
+            cell_bc
+        } else {
+            (sample_idx << cell_bc_bits) | (cell_bc & cell_bc_mask)
+        }
     };
 
     // Read metadata
@@ -1470,20 +1514,44 @@ where
         }
     }
 
-    // Load sample_permit_map.bin
-    let sample_map_file = File::open(parent.join("sample_permit_map.bin"))
-        .context("couldn't open sample_permit_map.bin")?;
-    let sample_permit_map: HashMap<u64, u64> =
+    let compact_path = parent.join(CORRECTION_PLAN_FILENAME);
+    let mut compact_correction_plan = if compact_path.exists() {
+        let plan = CorrectionPlan::read_from(&compact_path)?;
+        if plan.sample_barcode_len.is_none() || u32::from(plan.cell_barcode_len) != cell_bc_len {
+            return Err(anyhow!(
+                "correction plan does not match this multi-barcode RAD input"
+            ));
+        }
+        Some(plan)
+    } else {
+        warn!(
+            log,
+            "No correction_plan.bin was found for this multi-barcode run; using the historical sample map and on-the-fly Hamming-1 Unique cell correction. Rerun generate-permit-list to reproduce newer correction policies."
+        );
+        None
+    };
+
+    let sample_permit_map: HashMap<u64, u64> = if let Some(plan) = &compact_correction_plan {
+        plan.sample_corrections
+            .iter()
+            .map(|entry| (entry.observed, entry.corrected))
+            .collect()
+    } else {
+        let sample_map_file = File::open(parent.join("sample_permit_map.bin"))
+            .context("couldn't open sample_permit_map.bin")?;
         bincode::deserialize_from(BufReader::new(sample_map_file))
-            .map_err(|e| anyhow!("couldn't deserialize sample_permit_map.bin: {}", e))?;
+            .map_err(|e| anyhow!("couldn't deserialize sample_permit_map.bin: {}", e))?
+    };
 
     // Build sample_bc -> sample_idx mapping
     let mut sample_bc_to_idx: HashMap<u64, usize> = HashMap::new();
     let mut sample_names: Vec<String> = Vec::new();
+    let mut canonical_sample_barcodes = Vec::with_capacity(sample_entries.len());
     for (idx, entry) in sample_entries.iter().enumerate() {
         let bc_str = entry["barcode"].as_str().unwrap_or("0x0");
         let bc = u64::from_str_radix(bc_str.trim_start_matches("0x"), 16).unwrap_or(0);
         sample_bc_to_idx.insert(bc, idx);
+        canonical_sample_barcodes.push(bc);
         sample_names.push(
             entry["name"]
                 .as_str()
@@ -1540,7 +1608,7 @@ where
     }
 
     // Sort cell frequencies: group by sample_idx first, then by frequency descending
-    all_cell_freqs.sort_by(|a, b| a.2.cmp(&b.2).then(b.1.cmp(&a.1)));
+    all_cell_freqs.sort_by(|a, b| a.2.cmp(&b.2).then(b.1.cmp(&a.1)).then(a.0.cmp(&b.0)));
 
     // Build a sparse-plate-sidx -> manifest-ordinal map.  `sample_idx` so far
     // is a position in `sample_entries` (the full chemistry plate, e.g. 384
@@ -1692,18 +1760,40 @@ where
         })
         .collect();
     let total_valid_cells: usize = per_sample_valid_bcs.iter().map(Vec::len).sum();
+    // Consume compact scopes as libradicl takes ownership of their decisions.
+    // This avoids retaining the full decoded artifact alongside the optimized
+    // collation lookup for the duration of scatter and gather.
+    let mut compact_cell_scopes = compact_correction_plan.take().map(|plan| {
+        plan.cell_scopes
+            .into_iter()
+            .filter_map(|scope| scope.sample_barcode.map(|sample| (sample, scope)))
+            .collect::<HashMap<_, _>>()
+    });
     let mut sample_corrections = Vec::with_capacity(per_sample_valid_bcs.len());
     for (sample_index, valid_barcodes) in per_sample_valid_bcs.into_iter().enumerate() {
         let ordinal = sidx_to_ord[sample_index];
-        let correction = MultiBarcodeSampleCorrection::new(
-            if ordinal == usize::MAX {
-                0
-            } else {
-                ordinal as u64
-            },
-            valid_barcodes,
-            cell_bc_len,
-        );
+        let output_ordinal = if ordinal == usize::MAX {
+            0
+        } else {
+            ordinal as u64
+        };
+        let correction = if let Some(scopes) = &mut compact_cell_scopes {
+            let canonical_sample = canonical_sample_barcodes[sample_index];
+            let scope = scopes.remove(&canonical_sample).with_context(|| {
+                format!(
+                    "correction plan has no cell scope for canonical sample 0x{canonical_sample:x}"
+                )
+            })?;
+            MultiBarcodeSampleCorrection::from_corrections(
+                output_ordinal,
+                scope
+                    .corrections
+                    .into_iter()
+                    .map(|entry| (entry.observed, entry.corrected)),
+            )?
+        } else {
+            MultiBarcodeSampleCorrection::new(output_ordinal, valid_barcodes, cell_bc_len)
+        };
         sample_corrections.push(correction);
     }
     info!(
@@ -1721,6 +1811,17 @@ where
         cell_bc_bits as u32,
         bucket_summaries.len(),
     )?);
+    // Unmapped correction also needs the scatter lookup. Complete it before
+    // transferring the sole plan Arc to libradicl, which can then release the
+    // large correction index before its gather working set is allocated.
+    let unmapped_file = i_dir.join("unmapped_bc_count.bin");
+    correct_unmapped_counts_multi_bc(
+        &unmapped_file,
+        &sample_permit_map,
+        &sample_bc_to_idx,
+        plan.samples(),
+        parent,
+    );
     info!(
         log,
         "Starting libradicl multi-barcode collation with {} workers and a {:.2} GiB memory budget",
@@ -1731,7 +1832,7 @@ where
         &mut br,
         prelude.hdr.num_chunks,
         rec_context.clone(),
-        plan.clone(),
+        plan,
         owriter.clone(),
         parent,
         expected_ori.into(),
@@ -1754,16 +1855,6 @@ where
         engine_stats.num_scatter_workers,
         engine_stats.num_gather_workers,
         engine_stats.spool_flush_limit / 1024,
-    );
-
-    // Correct unmapped barcode counts for multi-barcode data
-    let unmapped_file = i_dir.join("unmapped_bc_count.bin");
-    correct_unmapped_counts_multi_bc(
-        &unmapped_file,
-        &sample_permit_map,
-        &sample_bc_to_idx,
-        plan.samples(),
-        parent,
     );
 
     // Build the manifest from the aggregate counts computed before collation.

--- a/src/correction_plan.rs
+++ b/src/correction_plan.rs
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2020-2024 COMBINE-lab.
+ *
+ * This file is part of alevin-fry
+ * (see https://www.github.com/COMBINE-lab/alevin-fry).
+ *
+ * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
+ */
+
+//! Stable handoff of GPL correction decisions to collation and ATAC sorting.
+
+use crate::barcode_correction::{CorrectionSpec, CorrectionTable};
+use anyhow::{Context, bail};
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+pub const CORRECTION_PLAN_FILENAME: &str = "correction_plan.bin";
+const MAGIC: &[u8; 8] = b"AFCORR\0\0";
+const FORMAT_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BarcodeCorrection {
+    pub observed: u64,
+    pub corrected: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CellCorrectionScope {
+    /// `None` for an ordinary single-barcode experiment; otherwise the
+    /// canonical sample barcode.
+    pub sample_barcode: Option<u64>,
+    pub spec: CorrectionSpec,
+    pub corrections: Vec<BarcodeCorrection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorrectionPlan {
+    pub sample_barcode_len: Option<u8>,
+    pub cell_barcode_len: u8,
+    pub sample_spec: Option<CorrectionSpec>,
+    pub sample_corrections: Vec<BarcodeCorrection>,
+    pub cell_scopes: Vec<CellCorrectionScope>,
+}
+
+impl CorrectionPlan {
+    pub fn single(spec: CorrectionSpec, table: &CorrectionTable<u64>) -> Self {
+        Self {
+            sample_barcode_len: None,
+            cell_barcode_len: spec.barcode_len,
+            sample_spec: None,
+            sample_corrections: Vec::new(),
+            cell_scopes: vec![CellCorrectionScope {
+                sample_barcode: None,
+                spec,
+                corrections: table
+                    .entries()
+                    .iter()
+                    .map(|&(observed, corrected)| BarcodeCorrection {
+                        observed,
+                        corrected,
+                    })
+                    .collect(),
+            }],
+        }
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        validate_len(self.cell_barcode_len, "cell")?;
+        if let Some(len) = self.sample_barcode_len {
+            validate_len(len, "sample")?;
+        }
+        match self.sample_barcode_len {
+            None => {
+                if self.sample_spec.is_some() || !self.sample_corrections.is_empty() {
+                    bail!("single-barcode correction plan contains sample-correction information");
+                }
+                if self.cell_scopes.len() != 1 || self.cell_scopes[0].sample_barcode.is_some() {
+                    bail!(
+                        "single-barcode correction plan must contain exactly one global cell scope"
+                    );
+                }
+            }
+            Some(_) => {
+                if self.cell_scopes.is_empty()
+                    || self
+                        .cell_scopes
+                        .iter()
+                        .any(|scope| scope.sample_barcode.is_none())
+                {
+                    bail!(
+                        "multi-barcode correction plan must contain sample-scoped cell corrections"
+                    );
+                }
+            }
+        }
+        if let Some(spec) = self.sample_spec {
+            spec.validate()?;
+            if Some(spec.barcode_len) != self.sample_barcode_len {
+                bail!("correction plan sample specification has the wrong barcode length");
+            }
+        }
+        validate_corrections(
+            &self.sample_corrections,
+            self.sample_barcode_len.unwrap_or(1),
+            "sample",
+        )?;
+
+        let mut previous_scope = None;
+        for scope in &self.cell_scopes {
+            scope.spec.validate()?;
+            if scope.spec.barcode_len != self.cell_barcode_len {
+                bail!("correction plan cell scope has the wrong barcode length");
+            }
+            if let Some(previous) = previous_scope
+                && previous >= scope.sample_barcode
+            {
+                bail!("correction plan cell scopes are not strictly ordered");
+            }
+            if let (Some(sample_barcode), Some(sample_len)) =
+                (scope.sample_barcode, self.sample_barcode_len)
+            {
+                validate_barcode(sample_barcode, sample_len, "sample scope")?;
+            }
+            previous_scope = Some(scope.sample_barcode);
+            validate_corrections(&scope.corrections, self.cell_barcode_len, "cell")?;
+        }
+        Ok(())
+    }
+
+    pub fn write_to(&mut self, output_dir: &Path) -> anyhow::Result<PathBuf> {
+        self.sample_corrections
+            .sort_unstable_by_key(|entry| entry.observed);
+        self.cell_scopes
+            .sort_unstable_by_key(|scope| scope.sample_barcode);
+        for scope in &mut self.cell_scopes {
+            scope
+                .corrections
+                .sort_unstable_by_key(|entry| entry.observed);
+        }
+        self.validate()?;
+
+        std::fs::create_dir_all(output_dir).with_context(|| {
+            format!(
+                "could not create correction plan directory {}",
+                output_dir.display()
+            )
+        })?;
+        let path = output_dir.join(CORRECTION_PLAN_FILENAME);
+        let temporary = output_dir.join(format!(".{CORRECTION_PLAN_FILENAME}.tmp"));
+        {
+            let file = File::create(&temporary).with_context(|| {
+                format!("could not create correction plan {}", temporary.display())
+            })?;
+            let mut writer = BufWriter::new(file);
+            writer.write_all(MAGIC)?;
+            writer.write_all(&FORMAT_VERSION.to_le_bytes())?;
+            bincode::serialize_into(&mut writer, self)
+                .context("could not serialize correction plan")?;
+            writer.flush()?;
+        }
+        std::fs::rename(&temporary, &path).with_context(|| {
+            format!(
+                "could not install correction plan {} as {}",
+                temporary.display(),
+                path.display()
+            )
+        })?;
+        Ok(path)
+    }
+
+    pub fn read_from(path: &Path) -> anyhow::Result<Self> {
+        let file = File::open(path)
+            .with_context(|| format!("could not open correction plan {}", path.display()))?;
+        let mut reader = BufReader::new(file);
+        let mut magic = [0u8; MAGIC.len()];
+        reader.read_exact(&mut magic).with_context(|| {
+            format!("correction plan {} has a truncated header", path.display())
+        })?;
+        if &magic != MAGIC {
+            bail!("correction plan {} has invalid magic", path.display());
+        }
+        let mut version = [0u8; 2];
+        reader.read_exact(&mut version)?;
+        let version = u16::from_le_bytes(version);
+        if version != FORMAT_VERSION {
+            bail!(
+                "correction plan {} uses unsupported format version {} (expected {})",
+                path.display(),
+                version,
+                FORMAT_VERSION
+            );
+        }
+        let plan: Self = bincode::deserialize_from(&mut reader)
+            .context("could not deserialize correction plan")?;
+        let mut trailing = [0_u8; 1];
+        if reader.read(&mut trailing)? != 0 {
+            bail!("correction plan {} contains trailing data", path.display());
+        }
+        plan.validate()?;
+        Ok(plan)
+    }
+}
+
+fn validate_len(len: u8, kind: &str) -> anyhow::Result<()> {
+    if !(1..=32).contains(&len) {
+        bail!("correction plan declares invalid {kind} barcode length {len}");
+    }
+    Ok(())
+}
+
+fn validate_corrections(
+    corrections: &[BarcodeCorrection],
+    barcode_len: u8,
+    kind: &str,
+) -> anyhow::Result<()> {
+    let limit = if barcode_len == 32 {
+        None
+    } else {
+        Some(1u64 << (2 * barcode_len))
+    };
+    let mut previous = None;
+    for entry in corrections {
+        if let Some(limit) = limit
+            && (entry.observed >= limit || entry.corrected >= limit)
+        {
+            bail!("correction plan contains a {kind} barcode outside its declared length");
+        }
+        if previous.is_some_and(|value| value >= entry.observed) {
+            bail!("correction plan {kind} corrections are not strictly ordered");
+        }
+        previous = Some(entry.observed);
+    }
+    Ok(())
+}
+
+fn validate_barcode(barcode: u64, barcode_len: u8, kind: &str) -> anyhow::Result<()> {
+    if barcode_len < 32 && barcode >= (1_u64 << (2 * barcode_len)) {
+        bail!("correction plan contains a {kind} barcode outside its declared length");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::barcode_correction::{
+        BarcodeNeighborhood, BarcodeResolution, CorrectionIndex, RetainedSource,
+    };
+
+    #[test]
+    fn deterministic_round_trip() {
+        let spec = CorrectionSpec {
+            barcode_len: 2,
+            neighborhood: BarcodeNeighborhood::HammingOne,
+            resolution: BarcodeResolution::Unique,
+        };
+        let index = CorrectionIndex::new(
+            spec,
+            [RetainedSource {
+                source: 1,
+                target: 1,
+                exact_count: 3,
+            }],
+        )
+        .unwrap();
+        let table = index.compile_observed([(0, 2), (1, 3)]);
+        let mut plan = CorrectionPlan::single(spec, &table);
+        plan.cell_scopes[0].corrections.reverse();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = plan.write_to(dir.path()).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        let loaded = CorrectionPlan::read_from(&path).unwrap();
+        assert_eq!(loaded, plan);
+
+        loaded.clone().write_to(dir.path()).unwrap();
+        assert_eq!(bytes, std::fs::read(path).unwrap());
+    }
+
+    #[test]
+    fn present_malformed_artifact_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(CORRECTION_PLAN_FILENAME);
+        std::fs::write(&path, b"not a correction plan").unwrap();
+        assert!(CorrectionPlan::read_from(&path).is_err());
+    }
+
+    #[test]
+    fn mixed_scope_shapes_and_trailing_data_are_errors() {
+        let spec = CorrectionSpec {
+            barcode_len: 2,
+            neighborhood: BarcodeNeighborhood::HammingOne,
+            resolution: BarcodeResolution::Unique,
+        };
+        let malformed = CorrectionPlan {
+            sample_barcode_len: Some(2),
+            cell_barcode_len: 2,
+            sample_spec: None,
+            sample_corrections: Vec::new(),
+            cell_scopes: vec![CellCorrectionScope {
+                sample_barcode: None,
+                spec,
+                corrections: Vec::new(),
+            }],
+        };
+        assert!(malformed.validate().is_err());
+
+        let index = CorrectionIndex::new(
+            spec,
+            [RetainedSource {
+                source: 1,
+                target: 1,
+                exact_count: 1,
+            }],
+        )
+        .unwrap();
+        let mut valid = CorrectionPlan::single(spec, &index.compile_observed([(1, 1)]));
+        let dir = tempfile::tempdir().unwrap();
+        let path = valid.write_to(dir.path()).unwrap();
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes.push(0);
+        std::fs::write(&path, bytes).unwrap();
+        assert!(CorrectionPlan::read_from(&path).is_err());
+    }
+}

--- a/src/correction_spool.rs
+++ b/src/correction_spool.rs
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2020-2024 COMBINE-lab.
+ *
+ * This file is part of alevin-fry
+ * (see https://www.github.com/COMBINE-lab/alevin-fry).
+ *
+ * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
+ */
+
+//! Private bounded spill/replay for ambiguous sample/cell pairs.
+
+use anyhow::{Context, bail};
+use snap::read::FrameDecoder;
+use snap::write::FrameEncoder;
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_SPOOL: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SpoolStats {
+    pub runs: u64,
+    pub pairs: u64,
+    pub encoded_pairs: u64,
+    pub uncompressed_bytes: u64,
+    pub compressed_bytes: u64,
+}
+
+/// A worker-local sequence of independently sorted, run-length encoded runs.
+///
+/// The file is removed on drop, including error unwinds. Runs do not need a
+/// global merge because replay is purely additive.
+pub(crate) struct DeferredPairSpool {
+    path: PathBuf,
+    writer: Option<FrameEncoder<BufWriter<File>>>,
+    buffer: Vec<(u64, u64)>,
+    max_pairs: usize,
+    stats: SpoolStats,
+    finished: bool,
+}
+
+impl DeferredPairSpool {
+    pub fn new(directory: &Path, worker: usize, max_pairs: usize) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(directory).with_context(|| {
+            format!(
+                "could not create correction spool directory {}",
+                directory.display()
+            )
+        })?;
+        let (path, file) = create_unique_file(directory, worker)?;
+        Ok(Self {
+            path,
+            writer: Some(FrameEncoder::new(BufWriter::new(file))),
+            buffer: Vec::with_capacity(max_pairs.max(1)),
+            max_pairs: max_pairs.max(1),
+            stats: SpoolStats::default(),
+            finished: false,
+        })
+    }
+
+    pub fn push(&mut self, sample: u64, cell: u64) -> anyhow::Result<()> {
+        if self.finished {
+            bail!("attempted to append to a finished correction spool");
+        }
+        self.buffer.push((sample, cell));
+        self.stats.pairs += 1;
+        if self.buffer.len() >= self.max_pairs {
+            self.flush_run()?;
+        }
+        Ok(())
+    }
+
+    pub fn finish(&mut self) -> anyhow::Result<()> {
+        if self.finished {
+            return Ok(());
+        }
+        self.flush_run()?;
+        let encoder = self
+            .writer
+            .take()
+            .expect("unfinished correction spool has a writer");
+        let mut writer = encoder.into_inner().map_err(|error| error.into_error())?;
+        writer.flush()?;
+        drop(writer);
+        self.stats.compressed_bytes = std::fs::metadata(&self.path)?.len();
+        self.finished = true;
+        Ok(())
+    }
+
+    pub fn replay(
+        &mut self,
+        mut consume: impl FnMut(u64, u64, u64) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        self.finish()?;
+        let file = File::open(&self.path)
+            .with_context(|| format!("could not open correction spool {}", self.path.display()))?;
+        let mut decoder = FrameDecoder::new(BufReader::new(file));
+        loop {
+            let Some(entries) = read_optional_u64(&mut decoder)? else {
+                break;
+            };
+            for _ in 0..entries {
+                let sample = read_u64(&mut decoder)?;
+                let cell = read_u64(&mut decoder)?;
+                let count = read_u64(&mut decoder)?;
+                if count == 0 {
+                    bail!("correction spool contains a zero-length run");
+                }
+                consume(sample, cell, count)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn stats(&self) -> SpoolStats {
+        self.stats
+    }
+
+    #[cfg(test)]
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn flush_run(&mut self) -> anyhow::Result<()> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+        self.buffer.sort_unstable();
+        let encoded_pairs = 1 + self
+            .buffer
+            .windows(2)
+            .filter(|pair| pair[0] != pair[1])
+            .count();
+
+        let writer = self
+            .writer
+            .as_mut()
+            .expect("unfinished correction spool has a writer");
+        writer.write_all(&(encoded_pairs as u64).to_le_bytes())?;
+        let mut start = 0;
+        while start < self.buffer.len() {
+            let pair = self.buffer[start];
+            let mut end = start + 1;
+            while end < self.buffer.len() && self.buffer[end] == pair {
+                end += 1;
+            }
+            writer.write_all(&pair.0.to_le_bytes())?;
+            writer.write_all(&pair.1.to_le_bytes())?;
+            writer.write_all(&((end - start) as u64).to_le_bytes())?;
+            start = end;
+        }
+        self.stats.runs += 1;
+        self.stats.encoded_pairs += encoded_pairs as u64;
+        self.stats.uncompressed_bytes += 8 + 24 * encoded_pairs as u64;
+        self.buffer.clear();
+        Ok(())
+    }
+}
+
+impl Drop for DeferredPairSpool {
+    fn drop(&mut self) {
+        self.writer.take();
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn create_unique_file(directory: &Path, worker: usize) -> anyhow::Result<(PathBuf, File)> {
+    loop {
+        let ordinal = NEXT_SPOOL.fetch_add(1, Ordering::Relaxed);
+        let path = directory.join(format!(
+            ".af-correction-{}-{worker}-{ordinal}.sz",
+            std::process::id()
+        ));
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("could not create correction spool {}", path.display())
+                });
+            }
+        }
+    }
+}
+
+fn read_optional_u64(reader: &mut impl Read) -> anyhow::Result<Option<u64>> {
+    let mut bytes = [0u8; 8];
+    let mut filled = 0;
+    while filled < bytes.len() {
+        match reader.read(&mut bytes[filled..]) {
+            Ok(0) if filled == 0 => return Ok(None),
+            Ok(0) => bail!("correction spool is truncated"),
+            Ok(read) => filled += read,
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(Some(u64::from_le_bytes(bytes)))
+}
+
+fn read_u64(reader: &mut impl Read) -> anyhow::Result<u64> {
+    read_optional_u64(reader)?.context("correction spool is truncated")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_one_and_many_runs_replay_identically_and_cleanup() {
+        for (max_pairs, pairs, expected_runs) in [
+            (4, Vec::new(), 0),
+            (4, vec![(1, 2), (1, 2), (3, 4)], 1),
+            (2, vec![(1, 2), (1, 2), (3, 4), (1, 2), (3, 4)], 3),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let path;
+            {
+                let mut spool = DeferredPairSpool::new(dir.path(), 0, max_pairs).unwrap();
+                path = spool.path().to_path_buf();
+                for &(sample, cell) in &pairs {
+                    spool.push(sample, cell).unwrap();
+                }
+                let mut replayed = std::collections::BTreeMap::new();
+                spool
+                    .replay(|sample, cell, count| {
+                        *replayed.entry((sample, cell)).or_insert(0) += count;
+                        Ok(())
+                    })
+                    .unwrap();
+                let mut expected = std::collections::BTreeMap::new();
+                for pair in pairs {
+                    *expected.entry(pair).or_insert(0) += 1;
+                }
+                assert_eq!(replayed, expected);
+                assert_eq!(spool.stats().runs, expected_runs);
+                assert!(path.exists());
+            }
+            assert!(!path.exists());
+        }
+    }
+
+    #[test]
+    fn corrupt_spool_is_reported_and_still_cleaned_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let path;
+        {
+            let mut spool = DeferredPairSpool::new(dir.path(), 0, 2).unwrap();
+            spool.push(1, 2).unwrap();
+            spool.finish().unwrap();
+            path = spool.path().to_path_buf();
+            std::fs::write(&path, b"not a snappy frame").unwrap();
+            assert!(spool.replay(|_, _, _| Ok(())).is_err());
+            assert!(path.exists());
+        }
+        assert!(!path.exists());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,14 @@
  */
 
 pub mod atac;
+pub mod barcode_correction;
 pub mod cellfilter;
 pub mod cmd_parse_utils;
 pub mod collate;
 pub mod constants;
 pub mod convert;
+pub mod correction_plan;
+mod correction_spool;
 pub mod diagnostics;
 pub mod em;
 pub mod eq_class;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use rand::RngExt;
 use slog::{Drain, crit, info, o, warn};
 use std::path::PathBuf;
 
+use alevin_fry::barcode_correction::{BarcodeNeighborhood, Confidence};
 use alevin_fry::cellfilter::{CellFilterMethod, generate_permit_list};
 use alevin_fry::cmd_parse_utils::{
     pathbuf_directory_exists_validator, pathbuf_file_exists_validator,
@@ -194,7 +195,6 @@ fn main() -> anyhow::Result<()> {
         .arg(
             arg!(-u --"unfiltered-pl" <UNFILTEREDPL> "uses an unfiltered external permit list")
             .value_parser(pathbuf_file_exists_validator)
-            .required_if_eq("cell-bc-correction", "frequency")
         )
         .group(ArgGroup::new("filter-method")
                .args(["knee-distance", "expect-cells", "force-cells", "valid-bc", "unfiltered-pl"])
@@ -215,15 +215,50 @@ fn main() -> anyhow::Result<()> {
                 .requires("sample-bc-list")
         )
         .arg(
-            arg!(--"sample-correction-mode" <SCMODE> "correction mode for sample barcodes")
+            arg!(--"sample-bc-correction" <SCMODE> "sample-barcode correction policy")
+                .value_parser(["exact", "unique", "frequency"])
+                .requires("sample-bc-list")
+                .conflicts_with("sample-correction-mode")
+        )
+        .arg(
+            arg!(--"sample-correction-mode" <SCMODE> "deprecated alias: exact, or 1-edit (Unique plus substitution-or-shift-1)")
                 .value_parser(["exact", "1-edit"])
-                .default_value("exact")
                 .requires("sample-bc-list")
         )
         .arg(
-            arg!(--"cell-bc-correction" <STRATEGY> "cell-barcode correction strategy for --unfiltered-pl: `unique` accepts only a unique retained neighbour (the default); `frequency` applies a Cell Ranger-inspired, uniform-quality rule and accepts the most frequent retained neighbour when it has at least 97.5% of the total Laplace-smoothed weight")
+            arg!(--"cell-bc-correction" <STRATEGY> "cell-barcode collision policy: `unique` accepts one canonical target; `frequency` uses frozen exact counts and a confidence threshold")
                 .value_parser(["unique", "frequency"])
                 .default_value("unique")
+        )
+        .arg(
+            arg!(--"cell-bc-neighborhood" <NEIGHBORHOOD> "cell-barcode neighbourhood; edit-1 is a compatibility alias for substitution-or-shift-1")
+                .value_parser(["hamming-1", "substitution-or-shift-1", "edit-1"])
+        )
+        .arg(
+            arg!(--"sample-bc-neighborhood" <NEIGHBORHOOD> "sample-barcode neighbourhood for non-exact correction")
+                .value_parser(["hamming-1", "substitution-or-shift-1", "edit-1"])
+                .default_value("hamming-1")
+                .requires("sample-bc-list")
+        )
+        .arg(
+            arg!(--"cell-bc-confidence" <CONFIDENCE> "Frequency confidence as a decimal or exact fraction")
+                .value_parser(value_parser!(Confidence))
+                .default_value("0.975")
+        )
+        .arg(
+            arg!(--"sample-bc-confidence" <CONFIDENCE> "sample-Frequency confidence as a decimal or exact fraction")
+                .value_parser(value_parser!(Confidence))
+                .default_value("0.975")
+                .requires("sample-bc-list")
+        )
+        .arg(
+            arg!(--"memory-limit" <MEMORY> "memory available to deferred GPL correction buffers")
+                .value_parser(parse_memory_size)
+                .default_value("512MiB")
+        )
+        .arg(
+            arg!(--"tmp-dir" <TMPDIR> "directory for temporary GPL correction spools (default: output directory)")
+                .value_parser(value_parser!(PathBuf))
         )
         .arg(
             arg!(--"sample-bc-ori" <SBCORI> "orientation of sample barcodes in the whitelist relative to the read (forward = whitelist matches read as-is; reverse = reverse-complement the whitelist before lookup, e.g. 10x Flex v2)")
@@ -452,12 +487,26 @@ fn main() -> anyhow::Result<()> {
         // Parse multi-barcode options
         let sample_bc_list: Option<PathBuf> = t.get_one::<PathBuf>("sample-bc-list").cloned();
         let sample_names: Option<PathBuf> = t.get_one::<PathBuf>("sample-names").cloned();
-        let sample_correction_mode = match t
-            .get_one::<String>("sample-correction-mode")
-            .map(|s| s.as_str())
+        let sample_correction_mode = if let Some(mode) =
+            t.get_one::<String>("sample-correction-mode")
         {
-            Some("1-edit") => prog_opts::SampleCorrectionMode::OneEdit,
-            _ => prog_opts::SampleCorrectionMode::Exact,
+            warn!(
+                log,
+                "--sample-correction-mode is deprecated; use --sample-bc-correction and --sample-bc-neighborhood"
+            );
+            match mode.as_str() {
+                "1-edit" => prog_opts::SampleCorrectionMode::OneEdit,
+                _ => prog_opts::SampleCorrectionMode::Exact,
+            }
+        } else {
+            match t
+                .get_one::<String>("sample-bc-correction")
+                .map(String::as_str)
+            {
+                Some("unique") => prog_opts::SampleCorrectionMode::Unique,
+                Some("frequency") => prog_opts::SampleCorrectionMode::Frequency,
+                _ => prog_opts::SampleCorrectionMode::Exact,
+            }
         };
 
         let cell_bc_correction = match t
@@ -472,6 +521,25 @@ fn main() -> anyhow::Result<()> {
             Some("reverse") => prog_opts::SampleBarcodeOri::Reverse,
             _ => prog_opts::SampleBarcodeOri::Forward,
         };
+
+        let cell_bc_neighborhood = t
+            .get_one::<String>("cell-bc-neighborhood")
+            .map(|value| value.parse::<BarcodeNeighborhood>())
+            .transpose()?;
+        let sample_bc_neighborhood = t
+            .get_one::<String>("sample-bc-neighborhood")
+            .expect("sample barcode neighbourhood has a default")
+            .parse::<BarcodeNeighborhood>()?;
+        let cell_bc_confidence = *t
+            .get_one::<Confidence>("cell-bc-confidence")
+            .expect("cell barcode confidence has a default");
+        let sample_bc_confidence = *t
+            .get_one::<Confidence>("sample-bc-confidence")
+            .expect("sample barcode confidence has a default");
+        let memory_limit = *t
+            .get_one::<u64>("memory-limit")
+            .expect("GPL memory limit has a default");
+        let tmp_dir = t.get_one::<PathBuf>("tmp-dir").cloned();
 
         let gpl_opts = GenPermitListOpts::builder()
             .input_dir(input_dir)
@@ -488,6 +556,12 @@ fn main() -> anyhow::Result<()> {
             .sample_correction_mode(sample_correction_mode)
             .sample_bc_ori(sample_bc_ori)
             .cell_bc_correction(cell_bc_correction)
+            .cell_bc_neighborhood(cell_bc_neighborhood)
+            .sample_bc_neighborhood(sample_bc_neighborhood)
+            .cell_bc_confidence(cell_bc_confidence)
+            .sample_bc_confidence(sample_bc_confidence)
+            .memory_limit(memory_limit)
+            .tmp_dir(tmp_dir)
             .build();
 
         match generate_permit_list(gpl_opts) {

--- a/src/prog_opts.rs
+++ b/src/prog_opts.rs
@@ -13,6 +13,9 @@ use serde::Serialize;
 use slog;
 use typed_builder::TypedBuilder;
 
+use crate::barcode_correction::{
+    BarcodeNeighborhood, BarcodeResolution, Confidence, CorrectionSpec,
+};
 use crate::cellfilter::CellFilterMethod;
 use crate::quant::{ResolutionStrategy, SplicedAmbiguityModel};
 
@@ -42,12 +45,29 @@ pub struct QuantOpts<'a, 'b, 'c, 'd, 'e, 'f, 'g> {
 }
 
 /// Correction mode for sample barcodes in multi-barcode protocols.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum SampleCorrectionMode {
     /// Exact match only — no error correction
     Exact,
-    /// Allow single-edit correction using BarcodeLookupMap
+    /// Accept a non-exact barcode only when it has one canonical target.
+    Unique,
+    /// Resolve competing canonical samples using frozen exact counts.
+    Frequency,
+    /// Deprecated compatibility spelling for Unique plus the historical
+    /// substitution-or-shift neighbourhood.
     OneEdit,
+}
+
+impl std::fmt::Display for SampleCorrectionMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Exact => f.write_str("exact"),
+            Self::Unique => f.write_str("unique"),
+            Self::Frequency => f.write_str("frequency"),
+            Self::OneEdit => f.write_str("1-edit"),
+        }
+    }
 }
 
 /// Orientation of the sample/probe barcodes in the whitelist relative to
@@ -92,6 +112,92 @@ pub struct GenPermitListOpts<'a, 'b, 'c, 'd, 'e> {
     /// unfiltered external permit list is used.
     #[builder(default)]
     pub cell_bc_correction: CellBarcodeCorrectionStrategy,
+    /// Explicit cell neighbourhood. `None` retains protocol/filter-specific
+    /// historical defaults.
+    #[builder(default)]
+    pub cell_bc_neighborhood: Option<BarcodeNeighborhood>,
+    /// Sample neighbourhood for the new Unique/Frequency modes.
+    #[builder(default = BarcodeNeighborhood::HammingOne)]
+    pub sample_bc_neighborhood: BarcodeNeighborhood,
+    #[builder(default = Confidence::RNA)]
+    pub cell_bc_confidence: Confidence,
+    #[builder(default = Confidence::RNA)]
+    pub sample_bc_confidence: Confidence,
+    /// Total memory available to deferred sample-Frequency buffers.
+    #[builder(default = 512_u64 << 20)]
+    pub memory_limit: u64,
+    /// Directory for correction spools; defaults to `output_dir`.
+    #[builder(default)]
+    pub tmp_dir: Option<PathBuf>,
+}
+
+impl GenPermitListOpts<'_, '_, '_, '_, '_> {
+    pub fn resolved_cell_neighborhood(&self, multi_barcode: bool) -> BarcodeNeighborhood {
+        self.cell_bc_neighborhood.unwrap_or({
+            if multi_barcode || matches!(self.fmeth, CellFilterMethod::UnfilteredExternalList(_, _))
+            {
+                BarcodeNeighborhood::HammingOne
+            } else {
+                BarcodeNeighborhood::SubstitutionOrShiftOne
+            }
+        })
+    }
+
+    pub fn cell_correction_spec(&self, barcode_len: u8, multi_barcode: bool) -> CorrectionSpec {
+        let resolution = match self.cell_bc_correction {
+            CellBarcodeCorrectionStrategy::Unique => BarcodeResolution::Unique,
+            CellBarcodeCorrectionStrategy::Frequency => BarcodeResolution::Frequency {
+                confidence: self.cell_bc_confidence,
+                pseudocount: 1,
+            },
+        };
+        CorrectionSpec {
+            barcode_len,
+            neighborhood: self.resolved_cell_neighborhood(multi_barcode),
+            resolution,
+        }
+    }
+
+    pub fn sample_correction_spec(&self, barcode_len: u8) -> Option<CorrectionSpec> {
+        let (neighborhood, resolution) = match self.sample_correction_mode {
+            SampleCorrectionMode::Exact => return None,
+            SampleCorrectionMode::Unique => {
+                (self.sample_bc_neighborhood, BarcodeResolution::Unique)
+            }
+            SampleCorrectionMode::Frequency => (
+                self.sample_bc_neighborhood,
+                BarcodeResolution::Frequency {
+                    confidence: self.sample_bc_confidence,
+                    pseudocount: 1,
+                },
+            ),
+            SampleCorrectionMode::OneEdit => (
+                BarcodeNeighborhood::SubstitutionOrShiftOne,
+                BarcodeResolution::Unique,
+            ),
+        };
+        Some(CorrectionSpec {
+            barcode_len,
+            neighborhood,
+            resolution,
+        })
+    }
+
+    /// Enforce the documented practical lower bound inside the library API,
+    /// not just in the CLI parser.
+    pub fn effective_memory_limit(&self) -> u64 {
+        const MINIMUM: u64 = 256_u64 << 20;
+        if self.memory_limit < MINIMUM {
+            slog::warn!(
+                self.log,
+                "Requested a {} byte GPL memory limit, but correction is not designed for less than 256 MiB; proceeding with 256 MiB.",
+                self.memory_limit
+            );
+            MINIMUM
+        } else {
+            self.memory_limit
+        }
+    }
 }
 
 /// How to resolve an unmatched barcode that is one substitution away from more

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1067,72 +1067,6 @@ pub fn generate_permitlist_map(
     Ok(one_edit_barcode_map)
 }
 
-/// Builds a one-edit correction map that retains only unambiguous corrections.
-///
-/// Exact permitted barcodes always map to themselves. A non-exact barcode is
-/// omitted when it is a one-edit neighbor of more than one permitted barcode.
-/// Unlike [`generate_permitlist_map`], the result is therefore independent of
-/// the order of `permit_bcs`. The historical public function remains unchanged
-/// for downstream callers that rely on its permissive behavior.
-pub(crate) fn generate_unambiguous_permitlist_map(
-    permit_bcs: &[u64],
-    bc_length: usize,
-) -> Result<HashMap<u64, u64>, Box<dyn Error>> {
-    generate_unambiguous_correction_map(permit_bcs, bc_length, |barcode| barcode)
-}
-
-/// Build an order-independent correction map from permitted source barcodes to
-/// caller-defined targets.
-///
-/// Multiple source barcodes may intentionally share a target, as happens when
-/// Flex sample-barcode rotations identify the same canonical sample. A neighbor
-/// is ambiguous only when its candidate sources lead to different targets.
-pub(crate) fn generate_unambiguous_correction_map<F>(
-    permit_bcs: &[u64],
-    bc_length: usize,
-    target_for: F,
-) -> Result<HashMap<u64, u64>, Box<dyn Error>>
-where
-    F: Fn(u64) -> u64,
-{
-    let mut correction_map = HashMap::with_capacity(10 * permit_bcs.len());
-    let mut exact_barcodes = HashSet::with_capacity(permit_bcs.len());
-    for &bc in permit_bcs {
-        exact_barcodes.insert(bc);
-        correction_map.insert(bc, target_for(bc));
-    }
-
-    let mut neighbors = HashSet::with_capacity(3 * bc_length + 8 * (bc_length - 1));
-    let mut ambiguous = HashSet::new();
-    for &bc in permit_bcs {
-        let target = target_for(bc);
-        get_all_one_edit_neighbors(bc, bc_length, &mut neighbors)?;
-        for &neighbor in &neighbors {
-            // An exact permitted source always keeps its explicit target,
-            // regardless of neighboring permitted sources.
-            if exact_barcodes.contains(&neighbor) {
-                continue;
-            }
-
-            if ambiguous.contains(&neighbor) {
-                continue;
-            }
-            match correction_map.get(&neighbor).copied() {
-                Some(previous) if previous != target => {
-                    correction_map.remove(&neighbor);
-                    ambiguous.insert(neighbor);
-                }
-                None => {
-                    correction_map.insert(neighbor, target);
-                }
-                _ => {}
-            }
-        }
-    }
-
-    Ok(correction_map)
-}
-
 /// Reads the contents of the file `flist`, which should contain
 /// a single barcode per-line, and returns a Result that is either
 /// a HashSet containing the k-mer encoding of all barcodes or
@@ -1230,13 +1164,12 @@ mod tests {
     use crate::utils::MIN_THREADS;
     use crate::utils::ProbMap;
     use crate::utils::enforce_thread_floor;
-    use crate::utils::generate_unambiguous_permitlist_map;
     use crate::utils::generate_whitelist_set;
     use crate::utils::get_all_indels;
     use crate::utils::get_all_one_edit_neighbors;
     use crate::utils::get_all_snps;
     use crate::utils::get_bit_mask;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashSet;
     use std::str::FromStr;
 
     #[test]
@@ -1320,42 +1253,6 @@ mod tests {
                 1, 3, 4, 5, 6, 9, 11, 12, 13, 14, 15, 23, 28, 29, 30, 31, 39, 55
             ]
         );
-    }
-
-    fn collision_map(permit_bcs: &[u64]) -> HashMap<u64, u64> {
-        generate_unambiguous_permitlist_map(permit_bcs, 2).unwrap()
-    }
-
-    #[test]
-    fn unambiguous_map_preserves_exact_and_unique_matches() {
-        let map = collision_map(&[0, 5]);
-        assert_eq!(map.get(&0), Some(&0));
-        assert_eq!(map.get(&5), Some(&5));
-        assert_eq!(map.get(&2), Some(&0));
-    }
-
-    #[test]
-    fn unambiguous_map_drops_ambiguous_neighbors() {
-        let forward = collision_map(&[0, 5]);
-        let reverse = collision_map(&[5, 0]);
-        assert!(!forward.contains_key(&1));
-        assert_eq!(forward, reverse);
-    }
-
-    #[test]
-    fn unambiguous_map_is_repeatable() {
-        let expected = collision_map(&[5, 0]);
-
-        std::thread::scope(|scope| {
-            for iteration in 0..32 {
-                let expected = &expected;
-                scope.spawn(move || {
-                    let input = if iteration % 2 == 0 { [0, 5] } else { [5, 0] };
-                    let actual = collision_map(&input);
-                    assert_eq!(&actual, expected);
-                });
-            }
-        });
     }
 
     #[test]

--- a/tests/multi_barcode_integration.rs
+++ b/tests/multi_barcode_integration.rs
@@ -503,6 +503,222 @@ fn test_multi_bc_generate_permit_list() {
 }
 
 #[test]
+fn sample_frequency_defers_only_ambiguous_pairs_and_collation_replays_decision() {
+    use alevin_fry::barcode_correction::BarcodeNeighborhood;
+    use alevin_fry::cellfilter::{CellFilterMethod, generate_permit_list};
+    use alevin_fry::collate::collate;
+    use alevin_fry::correction_plan::CorrectionPlan;
+    use alevin_fry::prog_opts::{GenPermitListOpts, SampleCorrectionMode};
+    use bio_types::strand::Strand;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let rad_dir = tmp.path().join("rad");
+    let output_dir = tmp.path().join("output");
+    std::fs::create_dir_all(&rad_dir).unwrap();
+    std::fs::create_dir_all(&output_dir).unwrap();
+
+    // Raw sample 1 is one substitution from both retained samples 0 and 2.
+    // Frozen exact priors (100 versus 1, with pseudocount one) make sample 0
+    // exceed the 97.5% threshold, so its ten pairs must be deferred then
+    // replayed into sample 0.
+    let retained_samples = [0_u64, 2_u64];
+    let ambiguous_sample = 1_u64;
+    let rejected_sample = 5_u64;
+    let cell = make_packed_bc(17, CELL_BC_LEN);
+    let (prelude, file_tag_map) = make_multi_bc_prelude();
+    let context = MultiBarcodeRecordContext::get_context_from_tag_section(
+        &prelude.file_tags,
+        &prelude.read_tags,
+        &prelude.aln_tags,
+    )
+    .unwrap();
+    let file = File::create(rad_dir.join("map.rad")).unwrap();
+    let mut writer = RadFileWriter::new(file, &prelude, &file_tag_map).unwrap();
+    for (sample, count) in [
+        (retained_samples[0], 100),
+        (retained_samples[1], 1),
+        (ambiguous_sample, 10),
+        (rejected_sample, 5),
+    ] {
+        let reads = (0..count)
+            .map(|umi| MultiBarcodeReadRecord {
+                barcodes: smallvec![sample, cell],
+                umi,
+                dirs: vec![true],
+                refs: vec![0],
+            })
+            .collect::<Vec<_>>();
+        writer
+            .write_chunk(
+                &Chunk::<MultiBarcodeReadRecord> {
+                    nbytes: 0,
+                    nrec: count as u32,
+                    reads,
+                },
+                &context,
+            )
+            .unwrap();
+    }
+    writer.finalize().unwrap();
+
+    let sample_list = tmp.path().join("samples.txt");
+    write_sample_bc_list(&sample_list, &retained_samples, SAMPLE_BC_LEN).unwrap();
+    let log = make_test_logger();
+    let opts = GenPermitListOpts::builder()
+        .input_dir(&rad_dir)
+        .output_dir(&output_dir)
+        .fmeth(CellFilterMethod::ForceCells(1))
+        .expected_ori(Strand::Unknown)
+        .version(TEST_VERSION)
+        .threads(2)
+        .velo_mode(false)
+        .cmdline("test")
+        .log(&log)
+        .sample_bc_list(Some(sample_list))
+        .sample_names(None)
+        .sample_correction_mode(SampleCorrectionMode::Frequency)
+        .sample_bc_neighborhood(BarcodeNeighborhood::HammingOne)
+        .build();
+    assert_eq!(generate_permit_list(opts).unwrap(), 2);
+
+    let info: serde_json::Value =
+        serde_json::from_reader(File::open(output_dir.join("sample_info.json")).unwrap()).unwrap();
+    assert_eq!(info["sample_routing"]["exact"], 101);
+    assert_eq!(info["sample_routing"]["deferred"], 10);
+    assert_eq!(info["sample_routing"]["deferred_accepted"], 10);
+    assert_eq!(info["sample_routing"]["deferred_rejected"], 0);
+    assert_eq!(info["sample_routing"]["immediate_rejected"], 5);
+    assert!(info["sample_routing"]["spill_runs"].as_u64().unwrap() >= 1);
+    assert_eq!(info["matched_reads"], 111);
+    assert_eq!(info["unmatched_reads"], 5);
+
+    let plan = CorrectionPlan::read_from(&output_dir.join("correction_plan.bin")).unwrap();
+    assert!(plan.sample_corrections.iter().any(|entry| {
+        entry.observed == ambiguous_sample && entry.corrected == retained_samples[0]
+    }));
+    assert!(std::fs::read_dir(&output_dir).unwrap().all(|entry| {
+        !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains(".af-correction-")
+    }));
+
+    collate(
+        output_dir.clone(),
+        &rad_dir,
+        2,
+        1_000,
+        false,
+        "test",
+        TEST_VERSION,
+        &log,
+    )
+    .unwrap();
+    let manifest =
+        CollationManifest::read_from_file(&output_dir.join("collation_manifest.bin")).unwrap();
+    assert_eq!(manifest.sample_groups.len(), 2);
+    assert_eq!(
+        manifest
+            .sample_groups
+            .iter()
+            .find(|group| group.key == retained_samples[0])
+            .unwrap()
+            .num_records,
+        110
+    );
+    assert_eq!(
+        manifest
+            .sample_groups
+            .iter()
+            .find(|group| group.key == retained_samples[1])
+            .unwrap()
+            .num_records,
+        1
+    );
+}
+
+#[test]
+fn filtered_multi_metadata_preserves_exact_reads_and_plan_is_thread_invariant() {
+    use alevin_fry::cellfilter::{CellFilterMethod, generate_permit_list};
+    use alevin_fry::correction_plan::CorrectionPlan;
+    use alevin_fry::prog_opts::{GenPermitListOpts, SampleCorrectionMode};
+    use bio_types::strand::Strand;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let rad_dir = tmp.path().join("rad");
+    std::fs::create_dir_all(&rad_dir).unwrap();
+
+    let sample = 0_u64;
+    let retained_cell = 0_u64;
+    let rescued_cell = 1_u64;
+    let (prelude, file_tag_map) = make_multi_bc_prelude();
+    let context = MultiBarcodeRecordContext::get_context_from_tag_section(
+        &prelude.file_tags,
+        &prelude.read_tags,
+        &prelude.aln_tags,
+    )
+    .unwrap();
+    let file = File::create(rad_dir.join("map.rad")).unwrap();
+    let mut writer = RadFileWriter::new(file, &prelude, &file_tag_map).unwrap();
+    for (cell, count) in [(retained_cell, 10_u32), (rescued_cell, 3_u32)] {
+        let reads = (0..count)
+            .map(|umi| MultiBarcodeReadRecord {
+                barcodes: smallvec![sample, cell],
+                umi: u64::from(umi),
+                dirs: vec![true],
+                refs: vec![0],
+            })
+            .collect();
+        writer
+            .write_chunk(
+                &Chunk::<MultiBarcodeReadRecord> {
+                    nbytes: 0,
+                    nrec: count,
+                    reads,
+                },
+                &context,
+            )
+            .unwrap();
+    }
+    writer.finalize().unwrap();
+
+    let sample_list = tmp.path().join("samples.txt");
+    write_sample_bc_list(&sample_list, &[sample], SAMPLE_BC_LEN).unwrap();
+    let log = make_test_logger();
+    let mut plan_bytes = Vec::new();
+    for threads in [2, 3] {
+        let output_dir = tmp.path().join(format!("output-{threads}"));
+        let opts = GenPermitListOpts::builder()
+            .input_dir(&rad_dir)
+            .output_dir(&output_dir)
+            .fmeth(CellFilterMethod::ForceCells(1))
+            .expected_ori(Strand::Unknown)
+            .version(TEST_VERSION)
+            .threads(threads)
+            .velo_mode(false)
+            .cmdline("test")
+            .log(&log)
+            .sample_bc_list(Some(sample_list.clone()))
+            .sample_names(None)
+            .sample_correction_mode(SampleCorrectionMode::Exact)
+            .build();
+        assert_eq!(generate_permit_list(opts).unwrap(), 1);
+
+        let info: serde_json::Value =
+            serde_json::from_reader(File::open(output_dir.join("sample_info.json")).unwrap())
+                .unwrap();
+        assert_eq!(info["samples"][0]["num_reads"], 10);
+        assert_eq!(info["samples"][0]["collatable_reads"], 13);
+
+        let plan = CorrectionPlan::read_from(&output_dir.join("correction_plan.bin")).unwrap();
+        assert_eq!(plan.cell_scopes[0].corrections.len(), 2);
+        plan_bytes.push(std::fs::read(output_dir.join("correction_plan.bin")).unwrap());
+    }
+    assert_eq!(plan_bytes[0], plan_bytes[1]);
+}
+
+#[test]
 fn test_multi_bc_collate_and_quant_preserve_sample_cell_identity() {
     use alevin_fry::cellfilter::{CellFilterMethod, generate_permit_list};
     use alevin_fry::collate::collate;


### PR DESCRIPTION
Implements the shared barcode-correction architecture for ordinary and multi-sample RNA. Depends on libradicl PR #56.

Highlights:
- central deterministic Hamming-1 / substitution-or-shift-1 engine with Unique and exact-rational Frequency policies
- all RNA filter modes share frozen-prior correction and aggregate corrected permit frequencies
- Exact, Unique, and Frequency sample correction, including one-pass bounded Snappy spill/replay for structurally ambiguous sample/cell pairs
- versioned correction_plan.bin handoff; collation applies compiled decisions directly and retains legacy fallbacks
- deterministic ordering, preserved legacy permit artifacts and sample_info meanings, explicit collatable_reads diagnostics
- deprecated sample 1-edit interface remains compatible

Validation:
- release all-target test suite and clippy with warnings denied pass
- correction plans invariant to whitelist ordering and thread count; malformed/trailing artifacts error
- full 39.9 GB Flex GPL median: 31.32 s vs 32.21 s baseline, RSS 1.78 GB vs 2.58 GB
- full Flex collate median: 21.92 s vs 24.50 s, RSS 1.24 GB vs 1.30 GB
- 2.6 GB single GPL median: 2.25 s vs 2.26 s, RSS 328 MiB vs 357 MiB
- single collate median: 1.65 s vs 1.77 s, RSS 897 MiB vs 907 MiB

ATAC integration and the detailed documentation/measurement report are intentionally split into follow-up stacked PRs.