### PR TITLE
Use shared deterministic correction in ATAC

### DIFF
--- a/src/atac/cellfilter.rs
+++ b/src/atac/cellfilter.rs
@@ -1,4 +1,8 @@
 use crate::atac::prog_opts::GenPermitListOpts;
+use crate::barcode_correction::{
+    BarcodeNeighborhood, BarcodeResolution, CorrectionIndex, RetainedSource,
+};
+use crate::correction_plan::{BarcodeCorrection, CellCorrectionScope, CorrectionPlan};
 use crate::diagnostics;
 use crate::utils as afutils;
 use anyhow::{Context, bail};
@@ -11,8 +15,6 @@ use std::sync::{
     atomic::{AtomicU64, AtomicUsize, Ordering as AtomicOrdering},
 };
 // use indexmap::map::IndexMap;
-use itertools::Itertools;
-use libradicl::BarcodeLookupMap;
 use libradicl::exit_codes;
 use libradicl::rad_types;
 use libradicl::rad_types::TagValue;
@@ -26,7 +28,6 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use std::time::Instant;
 
 type ParBCMap = DashMap<u64, u64, ahash::RandomState>;
 type BCMap = HashMap<u64, u64, ahash::RandomState>;
@@ -66,7 +67,7 @@ pub enum CellFilterMethod {
 
 pub fn update_barcode_hist_unfiltered(
     hist: &ParBCMap,
-    unmatched_bc: &mut Vec<u64>,
+    unmatched_bc: &mut BCMap,
     max_ambiguity_read: &mut usize,
     chunk: &chunk::Chunk<AtacSeqReadRecord>,
     bins: &[AtomicU64],
@@ -84,7 +85,7 @@ pub fn update_barcode_hist_unfiltered(
             Some(mut c) => *c += 1,
             // otherwise, push this into the unmatched list
             None => {
-                unmatched_bc.push(r.bc);
+                *unmatched_bc.entry(r.bc).or_insert(0) += 1;
             }
         }
 
@@ -141,7 +142,7 @@ fn populate_unfiltered_barcode_map<T: Read>(
 #[allow(clippy::unnecessary_unwrap, clippy::too_many_arguments)]
 fn process_unfiltered(
     hm: ParBCMap,
-    mut unmatched_bc: Vec<u64>,
+    unmatched_bc: BCMap,
     file_tag_map: &rad_types::TagMap,
     filter_meth: &CellFilterMethod,
     output_dir: &PathBuf,
@@ -164,168 +165,110 @@ fn process_unfiltered(
         }
     };
 
-    // the set of barcodes we'll keep
-    let mut kept_bc = Vec::<u64>::new();
-
-    // iterate over the count map
-    for mut kvp in hm.iter_mut() {
-        // if this satisfies our requirement for the minimum count
-        // then keep this barcode
-        if *kvp.value() >= min_freq {
-            kept_bc.push(*kvp.key());
-        } else {
-            // otherwise, we have to add this barcode's
-            // counts to our unmatched list
-            for _ in 0..*kvp.value() {
-                unmatched_bc.push(*kvp.key());
-            }
-            // and then reset the counter for this barcode to 0
-            *kvp.value_mut() = 0u64;
-        }
-    }
-
-    // drop the absent barcodes from hm
-    hm.retain(|_, &mut v| v > 0);
-
-    // how many we will keep
-    let num_passing = kept_bc.len();
-    info!(
-        log,
-        "num_passing = {}",
-        num_passing.to_formatted_string(&Locale::en)
-    );
     let barcode_tag = file_tag_map
         .get("cblen")
         .expect("tag map must contain cblen");
     let barcode_len: u16 = barcode_tag.try_into()?;
 
-    let bcmap2 = BarcodeLookupMap::new(kept_bc, barcode_len as u32);
+    let mut observed_counts: BCMap = HashMap::default();
+    let mut kept_barcodes = Vec::new();
+    for entry in &hm {
+        if *entry.value() > 0 {
+            observed_counts.insert(*entry.key(), *entry.value());
+        }
+        if *entry.value() >= min_freq {
+            kept_barcodes.push(*entry.key());
+        }
+    }
+    for (barcode, count) in unmatched_bc {
+        *observed_counts.entry(barcode).or_insert(0) += count;
+    }
+    kept_barcodes.sort_unstable();
+
+    let spec = gpl_opts.correction_spec(barcode_len as u8);
+    if matches!(spec.resolution, BarcodeResolution::Frequency { .. })
+        && spec.neighborhood == BarcodeNeighborhood::SubstitutionOrShiftOne
+    {
+        warn!(
+            log,
+            "ATAC Frequency correction is using substitution-or-shift-1. RAD stores no barcode base qualities or indel-error model, so this is an abundance heuristic rather than a calibrated indel posterior."
+        );
+    }
+    let correction_index = CorrectionIndex::new(
+        spec,
+        kept_barcodes.iter().map(|&barcode| RetainedSource {
+            source: barcode,
+            target: barcode,
+            exact_count: observed_counts.get(&barcode).copied().unwrap_or(0),
+        }),
+    )?;
     info!(
         log,
         "found {} cells with non-trivial number of reads by exact barcode match",
-        bcmap2.barcodes.len().to_formatted_string(&Locale::en)
+        kept_barcodes.len().to_formatted_string(&Locale::en)
     );
-
-    // finally, we'll go through the set of unmatched barcodes
-    // and try to rescue those that have a *unique* neighbor in the
-    // list of retained barcodes.
-
-    //let mut found_exact = 0usize;
-    let mut found_approx = 0usize;
-    let mut ambig_approx = 0usize;
-    let mut not_found = 0usize;
-
-    let start_unmatched_time = Instant::now();
-
-    unmatched_bc.sort_unstable();
-
-    let mut distinct_unmatched_bc = 0usize;
-    let mut distinct_recoverable_bc = 0usize;
-
-    // mapping the uncorrected barcode to what it corrects to
-    let mut corrected_list = Vec::<(u64, u64)>::with_capacity(1_000_000);
-
-    for (count, ubc) in unmatched_bc.iter().dedup_with_count() {
-        // try to find the unmatched barcode, but
-        // look up to 1 edit away
-        match bcmap2.find_neighbors(*ubc, false) {
-            // if we have a match
-            (Some(x), n) => {
-                let cbc = bcmap2.barcodes[x];
-                // if the uncorrected barcode had a
-                // single, unique retained neighbor
-                if cbc != *ubc && n == 1 {
-                    // then increment the count of this
-                    // barcode by 1 (because we'll correct to it)
-                    if let Some(mut c) = hm.get_mut(&cbc) {
-                        *c += count as u64;
-                        corrected_list.push((*ubc, cbc));
-                    }
-                    // this counts as an approximate find
-                    found_approx += count;
-                    distinct_recoverable_bc += 1;
-                }
-                // if we had > 1 single-mismatch neighbor
-                // then don't keep the barcode, but remember
-                // the count of such events
-                if n > 1 {
-                    ambig_approx += count;
-                }
-            }
-            // if we had no single-mismatch neighbor
-            // then this barcode is not_found and gets
-            // dropped.
-            (None, _) => {
-                not_found += count;
-            }
-        }
-        distinct_unmatched_bc += 1;
-    }
-    let unmatched_duration = start_unmatched_time.elapsed();
-    let num_corrected = distinct_recoverable_bc as u64;
-
+    let (correction_table, target_counts) = correction_index
+        .compile_distinct_observed_with_target_counts(
+            observed_counts
+                .iter()
+                .map(|(&barcode, &count)| (barcode, count)),
+        );
+    let permitted_counts: BCMap = target_counts.into_iter().collect();
+    let stats = correction_table.stats();
     info!(
         log,
-        "There were {} distinct unmatched barcodes, and {} that can be recovered",
-        distinct_unmatched_bc,
-        distinct_recoverable_bc
-    );
-    info!(
-        log,
-        "Matching unmatched barcodes to retained barcodes took {:?}", unmatched_duration
-    );
-    info!(log, "Of the unmatched barcodes\n============");
-    info!(
-        log,
-        "\t{} had exactly 1 single-edit neighbor in the retained list",
-        found_approx.to_formatted_string(&Locale::en)
-    );
-    info!(
-        log,
-        "\t{} had >1 single-edit neighbor in the retained list",
-        ambig_approx.to_formatted_string(&Locale::en)
-    );
-    info!(
-        log,
-        "\t{} had no neighbor in the retained list",
-        not_found.to_formatted_string(&Locale::en)
+        "ATAC cell correction: {} exact reads, {} corrected, {} ambiguous, {} without a candidate",
+        stats.exact_reads,
+        stats.corrected_reads,
+        stats.ambiguous_reads,
+        stats.not_found_reads,
     );
 
     let parent = std::path::Path::new(output_dir);
     let o_path = parent.join("permit_freq.bin");
 
-    // convert the DashMap to a HashMap
-    let mut hm: BCMap = hm.into_iter().collect();
-    match afutils::write_permit_list_freq(&o_path, barcode_len, &hm) {
+    match afutils::write_permit_list_freq(&o_path, barcode_len, &permitted_counts) {
         Ok(_) => {}
         Err(error) => {
             panic!("Error: {}", error);
         }
     };
 
-    /*
-    // don't need this right now
-    let s_path = parent.join("bcmap.bin");
-    let s_file = std::fs::File::create(&s_path).expect("could not create serialization file.");
-    let mut s_writer = BufWriter::new(&s_file);
-    bincode::serialize_into(&mut s_writer, &bcmap2).expect("couldn't serialize barcode list.");
-    */
-
-    // now that we are done with using hm to count, we can repurpose it as
-    // the correction map.
-    for (k, v) in hm.iter_mut() {
-        // each present barcode corrects to itself
-        *v = *k;
-    }
-    for (uncorrected, corrected) in corrected_list.iter() {
-        hm.insert(*uncorrected, *corrected);
-    }
+    let permit_map: BCMap = correction_table
+        .entries()
+        .iter()
+        .copied()
+        .filter(|(_, target)| permitted_counts.contains_key(target))
+        .collect();
 
     let pm_path = parent.join("permit_map.bin");
     let pm_file = std::fs::File::create(pm_path).context("could not create serialization file.")?;
     let mut pm_writer = BufWriter::new(&pm_file);
-    bincode::serialize_into(&mut pm_writer, &hm)
+    bincode::serialize_into(&mut pm_writer, &permit_map)
         .context("couldn't serialize permit list mapping.")?;
+
+    let compact_entries = correction_table
+        .entries()
+        .iter()
+        .copied()
+        .filter(|(_, target)| permitted_counts.contains_key(target))
+        .map(|(observed, corrected)| BarcodeCorrection {
+            observed,
+            corrected,
+        })
+        .collect();
+    let mut correction_plan = CorrectionPlan {
+        sample_barcode_len: None,
+        cell_barcode_len: barcode_len as u8,
+        sample_spec: None,
+        sample_corrections: Vec::new(),
+        cell_scopes: vec![CellCorrectionScope {
+            sample_barcode: None,
+            spec,
+            corrections: compact_entries,
+        }],
+    };
+    correction_plan.write_to(parent)?;
 
     let meta_info = json!({
     "version_str" : version,
@@ -334,7 +277,10 @@ fn process_unfiltered(
     "cmd" : cmdline,
     "permit-list-type" : "unfiltered",
     "gpl_options" : &gpl_opts,
-    "max-rec-in-bin": bmax
+    "max-rec-in-bin": bmax,
+    "resolved_cell_bc_neighborhood": spec.neighborhood.to_string(),
+    "resolved_cell_bc_confidence": gpl_opts.cell_bc_confidence.to_string(),
+    "correction_stats": stats,
     });
 
     let m_path = parent.join("generate_permit_list.json");
@@ -349,10 +295,10 @@ fn process_unfiltered(
     info!(
         log,
         "total number of distinct corrected barcodes : {}",
-        num_corrected.to_formatted_string(&Locale::en)
+        stats.corrected_distinct.to_formatted_string(&Locale::en)
     );
 
-    Ok(num_corrected)
+    Ok(stats.corrected_distinct)
 }
 
 pub fn generate_permit_list(gpl_opts: GenPermitListOpts) -> anyhow::Result<u64> {
@@ -492,7 +438,7 @@ pub fn generate_permit_list(gpl_opts: GenPermitListOpts) -> anyhow::Result<u64> 
     let num_reads = Arc::new(AtomicUsize::new(0));
     // if dealing with the unfiltered type
     // the set of barcodes that are not an exact match for any known barcodes
-    let mut unmatched_bc: Vec<u64>;
+    let mut unmatched_bc: BCMap;
     // let mut num_orientation_compat_reads = 0usize;
     let mut max_ambiguity_read = 0usize;
     let mut num_orientation_compat_reads = 0usize;
@@ -514,7 +460,7 @@ pub fn generate_permit_list(gpl_opts: GenPermitListOpts) -> anyhow::Result<u64> 
 
     match filter_meth {
         CellFilterMethod::UnfilteredExternalList(_, _min_reads) => {
-            unmatched_bc = Vec::with_capacity(10_000_000);
+            unmatched_bc = HashMap::default();
 
             // the unfiltered_bc_count map must be valid in this branch
             if unfiltered_bc_counts.is_some() {
@@ -529,7 +475,7 @@ pub fn generate_permit_list(gpl_opts: GenPermitListOpts) -> anyhow::Result<u64> 
                     let hmu = std::sync::Arc::new(unfiltered_bc_counts.unwrap());
                     let num_chunks = Arc::new(AtomicUsize::new(0));
                     let mut handles =
-                        Vec::<std::thread::ScopedJoinHandle<(usize, Vec<u64>, usize)>>::new();
+                        Vec::<std::thread::ScopedJoinHandle<(usize, BCMap, usize)>>::new();
                     for _ in 0..nworkers {
                         let chunks = rad_reader.chunk_iter();
                         let hmu = hmu.clone();
@@ -538,7 +484,7 @@ pub fn generate_permit_list(gpl_opts: GenPermitListOpts) -> anyhow::Result<u64> 
                         let num_reads = num_reads.clone();
                         let num_chunks = num_chunks.clone();
                         let handle = s.spawn(move || {
-                            let mut unmatched_bc = Vec::<u64>::new();
+                            let mut unmatched_bc: BCMap = HashMap::default();
                             let mut max_ambiguity_read = 0usize;
                             let mut num_orientation_compat_reads = 0;
                             for meta_chunk in chunks {
@@ -568,7 +514,9 @@ pub fn generate_permit_list(gpl_opts: GenPermitListOpts) -> anyhow::Result<u64> 
                     for handle in handles {
                         let (nocr, ubc, mar) = handle.join().expect("The parsing thread panicked");
                         num_orientation_compat_reads += nocr;
-                        unmatched_bc.extend_from_slice(&ubc);
+                        for (barcode, count) in ubc {
+                            *unmatched_bc.entry(barcode).or_insert(0) += count;
+                        }
                         max_ambiguity_read = max_ambiguity_read.max(mar);
                     }
                     pbar.finish_with_message("finished parsing RAD file\n");
@@ -603,7 +551,7 @@ pub fn generate_permit_list(gpl_opts: GenPermitListOpts) -> anyhow::Result<u64> 
                 let num_reads = num_reads.load(AtomicOrdering::Acquire);
                 let valid_thresh = 0.3f64;
                 match diagnostics::likely_valid_permit_list(
-                    unmatched_bc.len(),
+                    unmatched_bc.values().sum::<u64>() as usize,
                     num_reads,
                     valid_thresh,
                 ) {

--- a/src/atac/collate.rs
+++ b/src/atac/collate.rs
@@ -32,6 +32,7 @@ use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use slog::{crit, info, warn};
 //use anyhow::{anyhow, Result};
 use crate::constants as afconst;
+use crate::correction_plan::{CORRECTION_PLAN_FILENAME, CorrectionPlan};
 use crate::utils::InternalVersionInfo;
 use crossbeam_queue::ArrayQueue;
 // use dashmap::DashMap;
@@ -141,7 +142,7 @@ where
     // read the barcode length
     rdr.read_exact(&mut rbuf)
         .context("couldn't read freq file buffer")?;
-    let _bc_len = rbuf
+    let bc_len = rbuf
         .pread::<u64>(0)
         .context("couldn't read freq file barcode length")?;
 
@@ -153,7 +154,7 @@ where
 
     // sort this so that we deal with largest cells (by # of reads) first
     // sort in _descending_ order by count.
-    tsv_map.sort_unstable_by_key(|&a: &(u64, u64)| std::cmp::Reverse(a.1));
+    tsv_map.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
 
     /*
     let est_num_rounds = (total_to_collate as f64 / max_records as f64).ceil() as u64;
@@ -170,6 +171,7 @@ where
         rad_dir,
         num_threads,
         max_records,
+        bc_len,
         tsv_map,
         total_to_collate,
         compress_out,
@@ -285,6 +287,7 @@ pub fn collate_with_temp<P1, P2>(
     rad_dir: P2,
     num_threads: u32,
     max_records: u32,
+    bc_len: u64,
     tsv_map: Vec<(u64, u64)>,
     total_to_collate: u64,
     compress_out: bool,
@@ -453,10 +456,36 @@ where
         }
     }
 
-    // get the correction map
-    let cmfile = std::fs::File::open(parent.join("permit_map.bin"))
-        .context("couldn't open output permit_map.bin file")?;
-    let correct_map: Arc<HashMap<u64, u64>> = Arc::new(bincode::deserialize_from(&cmfile).unwrap());
+    let compact_path = parent.join(CORRECTION_PLAN_FILENAME);
+    let correct_map: Arc<HashMap<u64, u64>> = if compact_path.exists() {
+        let plan = CorrectionPlan::read_from(&compact_path)?;
+        if plan.sample_barcode_len.is_some() || u64::from(plan.cell_barcode_len) != bc_len {
+            return Err(anyhow!("correction plan does not match this ATAC input"));
+        }
+        let scope = plan
+            .cell_scopes
+            .iter()
+            .find(|scope| scope.sample_barcode.is_none())
+            .context("ATAC correction plan has no global cell scope")?;
+        Arc::new(
+            scope
+                .corrections
+                .iter()
+                .map(|entry| (entry.observed, entry.corrected))
+                .collect(),
+        )
+    } else {
+        warn!(
+            log,
+            "No correction_plan.bin was found; loading legacy permit_map.bin for ATAC collation"
+        );
+        let cmfile = File::open(parent.join("permit_map.bin"))
+            .context("couldn't open legacy permit_map.bin file")?;
+        Arc::new(
+            bincode::deserialize_from(&cmfile)
+                .context("couldn't deserialize legacy permit_map.bin")?,
+        )
+    };
 
     // NOTE: the assumption of where the unmapped file will be
     // should be robustified

--- a/src/atac/prog_opts.rs
+++ b/src/atac/prog_opts.rs
@@ -1,4 +1,8 @@
 use crate::atac::cellfilter::CellFilterMethod;
+use crate::barcode_correction::{
+    BarcodeNeighborhood, BarcodeResolution, Confidence, CorrectionSpec,
+};
+use crate::prog_opts::CellBarcodeCorrectionStrategy;
 use serde::Serialize;
 use slog;
 use std::path::PathBuf;
@@ -15,6 +19,28 @@ pub struct GenPermitListOpts<'a, 'b, 'c, 'd, 'e> {
     pub version: &'d str,
     #[serde(skip_serializing)]
     pub log: &'e slog::Logger,
+    #[builder(default)]
+    pub cell_bc_correction: CellBarcodeCorrectionStrategy,
+    #[builder(default = BarcodeNeighborhood::HammingOne)]
+    pub cell_bc_neighborhood: BarcodeNeighborhood,
+    #[builder(default = Confidence::ATAC)]
+    pub cell_bc_confidence: Confidence,
+}
+
+impl GenPermitListOpts<'_, '_, '_, '_, '_> {
+    pub fn correction_spec(&self, barcode_len: u8) -> CorrectionSpec {
+        CorrectionSpec {
+            barcode_len,
+            neighborhood: self.cell_bc_neighborhood,
+            resolution: match self.cell_bc_correction {
+                CellBarcodeCorrectionStrategy::Unique => BarcodeResolution::Unique,
+                CellBarcodeCorrectionStrategy::Frequency => BarcodeResolution::Frequency {
+                    confidence: self.cell_bc_confidence,
+                    pseudocount: 1,
+                },
+            },
+        }
+    }
 }
 
 #[derive(TypedBuilder, Debug, Serialize)]

--- a/src/atac/run.rs
+++ b/src/atac/run.rs
@@ -4,6 +4,8 @@ use crate::atac::collate::collate;
 use crate::atac::deduplicate::deduplicate;
 use crate::atac::prog_opts::{DeduplicateOpts, GenPermitListOpts};
 use crate::atac::sort::sort;
+use crate::barcode_correction::{BarcodeNeighborhood, Confidence};
+use crate::prog_opts::CellBarcodeCorrectionStrategy;
 use crate::utils::enforce_thread_floor;
 use anyhow::bail;
 use clap::ArgMatches;
@@ -46,6 +48,20 @@ pub fn run(opts: &ArgMatches, version: &str, cmdline: &str, log: &Logger) -> any
                 .expect("number of threads should be given"),
             log,
         ) as usize;
+        let cell_bc_correction = match t
+            .get_one::<String>("cell-bc-correction")
+            .map(String::as_str)
+        {
+            Some("frequency") => CellBarcodeCorrectionStrategy::Frequency,
+            _ => CellBarcodeCorrectionStrategy::Unique,
+        };
+        let cell_bc_neighborhood = t
+            .get_one::<String>("cell-bc-neighborhood")
+            .expect("ATAC cell neighbourhood has a default")
+            .parse::<BarcodeNeighborhood>()?;
+        let cell_bc_confidence = *t
+            .get_one::<Confidence>("cell-bc-confidence")
+            .expect("ATAC confidence has a default");
 
         let gpl_opts = GenPermitListOpts::builder()
             .input_dir(input_dir)
@@ -56,6 +72,9 @@ pub fn run(opts: &ArgMatches, version: &str, cmdline: &str, log: &Logger) -> any
             .version(version)
             .cmdline(cmdline)
             .log(log)
+            .cell_bc_correction(cell_bc_correction)
+            .cell_bc_neighborhood(cell_bc_neighborhood)
+            .cell_bc_confidence(cell_bc_confidence)
             .build();
 
         match generate_permit_list(gpl_opts) {

--- a/src/atac/sort.rs
+++ b/src/atac/sort.rs
@@ -1,10 +1,11 @@
 use crate::constants as afconst;
+use crate::correction_plan::{CORRECTION_PLAN_FILENAME, CorrectionPlan};
 use crate::utils as afutils;
 use afutils::InternalVersionInfo;
 use anyhow::{Context, anyhow};
 use crossbeam_queue::ArrayQueue;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use slog::{crit, info};
+use slog::{crit, info, warn};
 
 use libradicl::chunk;
 use libradicl::header::{RadHeader, RadPrelude};
@@ -255,7 +256,7 @@ where
     // read the barcode length
     rdr.read_exact(&mut rbuf)
         .context("couldn't read freq file buffer")?;
-    let _bc_len = rbuf
+    let bc_len = rbuf
         .pread::<u64>(0)
         .context("couldn't read freq file barcode length")?;
 
@@ -269,6 +270,7 @@ where
         rad_dir,
         num_threads,
         max_records,
+        bc_len,
         bin_rec_counts,
         bin_lens,
         tsv_map,
@@ -288,6 +290,7 @@ pub fn sort_with_temp<P1, P2>(
     rad_dir: P2,
     num_threads: u32,
     max_records: u32,
+    bc_len: u64,
     bin_recs: Vec<u64>,
     bin_lens: Vec<u64>,
     tsv_map: Vec<(u64, u64)>,
@@ -443,10 +446,36 @@ where
         }
     }
 
-    // get the correction map
-    let cmfile = std::fs::File::open(parent.join("permit_map.bin"))
-        .context("couldn't open output permit_map.bin file")?;
-    let correct_map: Arc<HashMap<u64, u64>> = Arc::new(bincode::deserialize_from(&cmfile).unwrap());
+    let compact_path = parent.join(CORRECTION_PLAN_FILENAME);
+    let correct_map: Arc<HashMap<u64, u64>> = if compact_path.exists() {
+        let plan = CorrectionPlan::read_from(&compact_path)?;
+        if plan.sample_barcode_len.is_some() || u64::from(plan.cell_barcode_len) != bc_len {
+            return Err(anyhow!("correction plan does not match this ATAC input"));
+        }
+        let scope = plan
+            .cell_scopes
+            .iter()
+            .find(|scope| scope.sample_barcode.is_none())
+            .context("ATAC correction plan has no global cell scope")?;
+        Arc::new(
+            scope
+                .corrections
+                .iter()
+                .map(|entry| (entry.observed, entry.corrected))
+                .collect(),
+        )
+    } else {
+        warn!(
+            log,
+            "No correction_plan.bin was found; loading legacy permit_map.bin for ATAC sorting"
+        );
+        let cmfile = File::open(parent.join("permit_map.bin"))
+            .context("couldn't open legacy permit_map.bin file")?;
+        Arc::new(
+            bincode::deserialize_from(&cmfile)
+                .context("couldn't deserialize legacy permit_map.bin")?,
+        )
+    };
 
     // NOTE: the assumption of where the unmapped file will be
     // should be robustified

--- a/src/main.rs
+++ b/src/main.rs
@@ -882,7 +882,22 @@ fn atac_sub_commands(num_hardware_threads: u32) -> Command {
         .arg(arg!(-d --"permit-bc-ori" <EXPECTEDORI> "the expected orientation of barcodes in the permit list")
              .ignore_case(true)
              .default_value("rc")
-             .value_parser(["fw", "rc"]));
+             .value_parser(["fw", "rc"]))
+        .arg(
+            arg!(--"cell-bc-correction" <STRATEGY> "cell-barcode collision policy")
+                .value_parser(["unique", "frequency"])
+                .default_value("unique")
+        )
+        .arg(
+            arg!(--"cell-bc-neighborhood" <NEIGHBORHOOD> "cell-barcode neighbourhood")
+                .value_parser(["hamming-1", "substitution-or-shift-1", "edit-1"])
+                .default_value("hamming-1")
+        )
+        .arg(
+            arg!(--"cell-bc-confidence" <CONFIDENCE> "Frequency confidence as a decimal or exact fraction")
+                .value_parser(value_parser!(Confidence))
+                .default_value("0.90")
+        );
 
     // Hidden: provisional, and not part of the supported scATAC-seq pipeline.
     // See the module comment on `atac::collate`.

--- a/tests/atac_integration.rs
+++ b/tests/atac_integration.rs
@@ -36,6 +36,9 @@ use alevin_fry::atac::cellfilter::{CellFilterMethod, generate_permit_list};
 use alevin_fry::atac::collate::collate;
 use alevin_fry::atac::deduplicate::deduplicate;
 use alevin_fry::atac::prog_opts::{DeduplicateOpts, GenPermitListOpts};
+use alevin_fry::atac::sort::sort;
+use alevin_fry::barcode_correction::{BarcodeNeighborhood, BarcodeResolution};
+use alevin_fry::correction_plan::CorrectionPlan;
 
 const TEST_VERSION: &str = "0.17.0";
 const CELL_BC_LEN: u16 = 16;
@@ -301,6 +304,24 @@ fn stage_permit_list(
         "synthetic barcodes match the whitelist exactly, so none should need correction"
     );
 
+    let correction_plan = CorrectionPlan::read_from(&gpl_dir.join("correction_plan.bin"))
+        .expect("ATAC GPL wrote no valid correction plan");
+    assert_eq!(correction_plan.cell_barcode_len, CELL_BC_LEN as u8);
+    assert_eq!(correction_plan.cell_scopes.len(), 1);
+    assert_eq!(
+        correction_plan.cell_scopes[0].spec.neighborhood,
+        BarcodeNeighborhood::HammingOne
+    );
+    assert_eq!(
+        correction_plan.cell_scopes[0].spec.resolution,
+        BarcodeResolution::Unique
+    );
+    assert_eq!(
+        correction_plan.cell_scopes[0].corrections.len(),
+        num_cells,
+        "the compact ATAC plan must include retained identities"
+    );
+
     // What we actually care about is the retained set, which lands in
     // permit_freq.bin. That file opens with two u64s — the format version and
     // the barcode length — before the bincode-encoded barcode -> count map.
@@ -356,6 +377,10 @@ fn atac_collate_tolerates_unmapped_and_multimapping_records() {
 
     let (rad_dir, gpl_dir) = stage_permit_list(tmp.path(), num_cells, &mix, &log);
 
+    // Prove this run consumes the compiled artifact rather than silently
+    // relying on the compatibility map.
+    std::fs::remove_file(gpl_dir.join("permit_map.bin")).unwrap();
+
     let gpl_for_collate = gpl_dir.clone();
     let rad_for_collate = rad_dir.clone();
     let collate_log = log.clone();
@@ -388,6 +413,39 @@ fn atac_collate_tolerates_unmapped_and_multimapping_records() {
     assert_eq!(
         prelude.hdr.num_chunks, num_cells as u64,
         "expected one collated chunk per cell"
+    );
+}
+
+#[test]
+fn atac_sort_uses_compiled_plan_without_legacy_map() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = make_test_logger();
+    let mix = CellMix {
+        good: 3,
+        unmapped: 0,
+        multimapped: 0,
+    };
+    let (rad_dir, gpl_dir) = stage_permit_list(tmp.path(), 4, &mix, &log);
+    std::fs::remove_file(gpl_dir.join("permit_map.bin")).unwrap();
+
+    let sort_input = gpl_dir.clone();
+    let sort_rad = rad_dir.clone();
+    let sort_log = log.clone();
+    run_with_timeout("atac sort with compiled correction plan", move || {
+        sort(
+            sort_input,
+            sort_rad,
+            2,
+            10_000,
+            false,
+            "atac_integration_test",
+            TEST_VERSION,
+            &sort_log,
+        )
+    });
+    assert!(
+        std::fs::metadata(gpl_dir.join("map.bed")).is_ok_and(|metadata| metadata.len() > 0),
+        "ATAC sort produced no BED output"
     );
 }
 


### PR DESCRIPTION
Stacked on #183.

This applies the same alevin-fry-owned correction engine and correction_plan.bin handoff to the ATAC pathway:
- ATAC GPL supports Unique or Frequency and Hamming-1 or substitution-or-shift-1
- defaults remain Hamming-1 Unique, with 90% as the resolved Frequency confidence
- observed unmatched barcodes are counted rather than stored once per read
- corrected reads are aggregated into permit_freq.bin
- both ATAC collation and genomic sorting consume the compact plan, with permit_map.bin fallback for older outputs
- barcode ties in ATAC collation are fully ordered

Tests verify the default plan and retained identities, and prove both collation and sorting work after the legacy map is removed. The full release test suite and clippy with warnings denied pass.