### PR TITLE
chore: prepare alevin-fry 0.18.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,11 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Strict API documentation
+      if: matrix.os == 'ubuntu-latest'
+      env:
+        RUSTDOCFLAGS: -D warnings
+      run: cargo doc --workspace --no-deps
 
   Linting:
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ Changelog for alevin-fry
 > releases 0.10.0 through 0.17.0 are not recorded here. See the git history and
 > the GitHub releases page for that range.
 
+## [0.18.0](https://github.com/COMBINE-lab/alevin-fry/compare/v0.17.1...v0.18.0) (2026-08-15)
+
+### Added
+
+* Deterministic, shared barcode correction for every ordinary-RNA filtering
+  mode, multi-sample RNA, and ATAC.  Cell barcodes support `unique` and
+  abundance-weighted `frequency` policies with Hamming-1 or the historical
+  substitution-or-shift neighbourhood; sample barcodes additionally support
+  exact correction.
+* A versioned `correction_plan.bin` handoff that records GPL's accepted
+  observed-barcode decisions.  Collation and ATAC sorting apply the compiled
+  decisions directly while retaining explicit fallbacks for older GPL output.
+* Bounded, Snappy-compressed spill and replay for the structurally ambiguous
+  sample-Frequency cases, controlled by `--memory-limit` and `--tmp-dir`.
+* User-selectable cell and sample Frequency confidence thresholds, exact
+  rational comparisons, correction diagnostics, and corrected
+  `permit_freq.bin` aggregation.
+
+### Changed
+
+* Single- and multi-barcode collation now use libradicl's bounded parallel
+  engines.  Their hot paths fuse correction and bucket routing into one lookup,
+  preserve hierarchical sample/cell output, and fully order manifests.
+* Requests below two threads warn and continue with two.  Collation and GPL
+  memory requests below 256 MiB likewise warn and continue with 256 MiB.
+* Legacy `--sample-correction-mode`, `--max-records`, and `--collation-mode`
+  spellings remain accepted but are hidden from normal help.
+* Quantification reuses sparse scratch storage and equivalence-class state;
+  bootstrap and summary-stat handling were corrected, and release builds abort
+  rather than unwind on panic.
+
+### Performance
+
+* On the 1.995-billion-record Flex v2 benchmark, bounded worker-local barcode
+  counts and private AHash execution maps reduced GPL median wall time from
+  31.39 to 9.35 seconds and peak RSS from 1,735.5 to 1,550.2 MiB while
+  producing byte-identical correction artifacts.
+* The optimized compiled-plan collators reduced measured Flex collation wall
+  time by 10.5% and single-barcode PBMC collation by 6.8% relative to their
+  immediate baselines.  ATAC sorting improved by 5.3% on the measured
+  28.4-million-record input with byte-identical BED output.
+
 ## [0.17.1](https://github.com/COMBINE-lab/alevin-fry/compare/v0.17.0...v0.17.1)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "alevin-fry"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -872,8 +872,9 @@ dependencies = [
 
 [[package]]
 name = "libradicl"
-version = "0.17.0"
-source = "git+https://github.com/COMBINE-lab/libradicl.git?rev=f2c5c899bf21bbc7d9437e4e2b3c1a7d1f7ff563#f2c5c899bf21bbc7d9437e4e2b3c1a7d1f7ff563"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1d9494fd770a1d6a07d679f6b722c48fea53dc9c64a4e95e13b71066308c4e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -898,8 +899,9 @@ dependencies = [
 
 [[package]]
 name = "libradicl-macros"
-version = "0.17.0"
-source = "git+https://github.com/COMBINE-lab/libradicl.git?rev=f2c5c899bf21bbc7d9437e4e2b3c1a7d1f7ff563#f2c5c899bf21bbc7d9437e4e2b3c1a7d1f7ff563"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dbcfb3a9fd7e663131c333ddc7ed932fc1c6a0d14ac75508992193c4bbb4e0d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "Rob Patro <rob@cs.umd.edu>",
 ]
 name = "alevin-fry"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2024"
 
 description = "A suite of tools for the rapid, accurate and memory-frugal processing single-cell and single-nucleus sequencing data."
@@ -35,7 +35,7 @@ keywords = [
 categories = ["command-line-utilities", "science"]
 
 [dependencies]
-libradicl = { version = "0.17.0", git = "https://github.com/COMBINE-lab/libradicl.git", rev = "f2c5c899bf21bbc7d9437e4e2b3c1a7d1f7ff563" }
+libradicl = "0.18.0"
 anyhow = "1.0.102"
 arrayvec = "0.7.6"
 ahash = { version = "0.8.12", features = ["serde"] }
@@ -86,7 +86,7 @@ clap = { version = "4.6.0", features = [
   "error-context",
 ] }
 
-# libradicl 0.17 depends on noodles 0.115; a mismatch here yields two
+# libradicl 0.18 depends on noodles 0.115; a mismatch here yields two
 # incompatible `sam::Header` types at the `RadHeader::from_bam_header` call in
 # src/convert.rs. Keep these in lockstep.
 noodles = { version = "0.115.0", features = ["bam", "bgzf", "sam"] }

--- a/docs/barcode-correction-measurements.md
+++ b/docs/barcode-correction-measurements.md
@@ -32,6 +32,26 @@ barcodes, read totals, and cell totals. Record order inside a cell is not part
 of the RAD contract and differed between parallel runs, so whole-file hashes
 are not expected to match.
 
+### 0.18.0 registry-dependency release gate
+
+Immediately before release, the full Flex GPL and collation measurements were
+repeated to compare current `master` (using its pinned libradicl Git revision)
+with the 0.18.0 release candidate (using `libradicl = "0.18.0"` from
+crates.io). Both builds used their locked release dependency graph.
+
+| Stage | Build | Wall times (s) | Median (s) | Peak RSS runs (KiB) | Median RSS (KiB) | RC change |
+|---|---|---:|---:|---:|---:|---:|
+| GPL | current master | 10.24, 10.27, 10.23 | 10.24 | 1,575,844; 1,598,820; 1,584,600 | 1,584,600 | — |
+| GPL | 0.18.0 RC | 9.95, 10.16, 10.37 | 10.16 | 1,590,256; 1,582,072; 1,619,352 | 1,590,256 | wall −0.8%; RSS +0.4% |
+| Collate | current master | 20.64, 20.99, 20.85 | 20.85 | 1,224,836; 1,255,840; 1,230,088 | 1,230,088 | — |
+| Collate | 0.18.0 RC | 21.20, 20.04, 21.14 | 21.14 | 1,237,232; 1,238,248; 1,252,016 | 1,238,248 | wall +1.4%; RSS +0.7% |
+
+All six GPL runs produced the same correction-plan hash. All six collations
+produced the same manifest hash, 2,423,889 chunks, 1,869,082,132 written
+records, and a 37,402,724,053-byte output. The registry transition therefore
+cleared the 3% wall-time and peak-RSS release gates without changing the
+output contract.
+
 The 2.6 GB unfiltered single-barcode PBMC GPL was also measured three times at
 8 threads. Baseline wall times were 2.25, 2.27, and 2.26 seconds (median 2.26)
 with median RSS 357,124 KiB. Feature times were 2.24, 2.25, and 2.35 seconds
@@ -49,6 +69,39 @@ seconds (median 1.65) with median RSS 896,504 KiB: wall −6.8% and RSS
 was found to amplify allocator high-water use; the final handoff instead
 borrows the one map for unmapped-read accounting and then moves it into
 libradicl's fused lookup.
+
+## Final hash and count aggregation optimization
+
+A subsequent release-candidate pass replaced private multi-sample routing and
+cell-count maps with AHash-based execution structures, made the immutable cell
+whitelist an `AHashSet`, and aggregated counts in bounded worker-local maps.
+The correction engine and persisted artifacts remained ordered and
+deterministic; the hash implementation is private and does not choose targets.
+
+The full Flex v2 input above was measured with 32 threads and three runs per
+main comparison:
+
+| Implementation | Median wall (s) | Median peak RSS (MiB) |
+|---|---:|---:|
+| Original resolved-correction GPL | 31.39 | 1,735.5 |
+| Fused route, SipHash | 28.80 | 1,697.9 |
+| Fused route, AHash | 19.43 | 1,741.5 |
+| Immutable AHash whitelist | 17.02 | 1,703.0 |
+| Bounded worker-local counts (final) | **9.35** | **1,550.2** |
+
+The final implementation reduced median wall time by 70.2% and peak RSS by
+10.7% relative to the original resolved-correction implementation.  The
+forced-cell path improved from 15.65 seconds / 1,402.3 MiB to 9.84 seconds /
+1,352.4 MiB.  Cell-Frequency and sample-Frequency completed in 8.03 and 8.14
+seconds and reproduced their pre-change correction artifacts byte-for-byte.
+
+A six-run FoldHash comparison at the fused-routing stage measured 19.22 seconds
+versus 19.43 seconds for AHash.  The roughly 1% and inconsistent difference did
+not justify another direct dependency or a different fixed-seed tradeoff.
+
+On a 28.4-million-record, 3.8 GB ATAC RAD, 13 paired warm-cache sort runs
+improved from 0.76 to 0.72 seconds median (5.3%).  The BED outputs were
+byte-identical.
 
 ## Neighbourhood effects
 

--- a/docs/source/barcode_correction.rst
+++ b/docs/source/barcode_correction.rst
@@ -111,6 +111,13 @@ barcode lengths and resolved policies, and stores sorted observed-to-corrected
 entries including retained identities.  Multi-sample cell corrections are
 grouped by canonical sample.
 
+The plan is an internal, versioned handoff between GPL and later stages, not a
+user-editable permit list or a stable interchange format.  Run GPL and
+collation or ATAC sorting with compatible alevin-fry releases, keep the file
+alongside the historical artifacts, and do not modify it.  A newer reader may
+support an older directory through the explicit fallbacks below; it will never
+guess how to interpret a present plan whose version it does not support.
+
 Collation validates the plan, compiles its sorted entries into a direct fused
 correction-and-bucket lookup, and performs one lookup on each RAD record.  The
 record hot path contains no neighbour generation, collision-policy dispatch,

--- a/docs/source/collate.rst
+++ b/docs/source/collate.rst
@@ -25,7 +25,9 @@ sample and cell-barcode tie-breaks.
 
 If ``correction_plan.bin`` is absent, collation uses the historical correction
 files and emits a warning.  A present but malformed or unsupported plan is an
-error; it is never silently ignored.
+error; it is never silently ignored.  This file is a versioned internal
+GPL-to-collate handoff and should be kept with the rest of the GPL output rather
+than edited or copied independently between incompatible releases.
 
 output
 ------

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -1,3 +1,5 @@
+.. _alevin-fry commands:
+
 ===================
 alevin-fry commands
 ===================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,11 +18,11 @@
 # -- Project information -----------------------------------------------------
 
 project = 'alevin-fry'
-copyright = '2021-2024, Dongze He, Mohsen Zakeri, Hirak Sarkar, Charlotte Soneson, Avi Srivastava, Noor Pratap Singh, Rob Patro'
+copyright = '2021-2026, Dongze He, Mohsen Zakeri, Hirak Sarkar, Charlotte Soneson, Avi Srivastava, Noor Pratap Singh, Rob Patro'
 author = 'Dongze He, Mohsen Zakeri, Hirak Sarkar, Charlotte Soneson, Avi Srivastava, Noor Pratap Singh, Rob Patro'
 
 # The full version, including alpha/beta/rc tags
-release = '0.11.0'
+release = '0.18.0'
 
 master_doc = 'index'
 
@@ -34,7 +34,7 @@ master_doc = 'index'
 extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = []
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -54,4 +54,4 @@ html_logo = '../logo.png'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []

--- a/docs/source/generate_permit_list.rst
+++ b/docs/source/generate_permit_list.rst
@@ -72,6 +72,6 @@ relevant to users of ``alevin-fry``, but the files are described here.
 
 3. ``permit_map.bin`` retains the historical serialized-map interface for older consumers.
 
-4. ``correction_plan.bin`` is the deterministic, versioned handoff consumed by current collation and ATAC sorting.  It contains the accepted observed corrections, including identities, and their resolved policy metadata.
+4. ``correction_plan.bin`` is the deterministic, versioned internal handoff consumed by current collation and ATAC sorting.  It contains the accepted observed corrections, including identities, and their resolved policy metadata.  It is not a user-editable permit list or stable interchange format; keep it with the complete GPL output and use compatible alevin-fry stages.
 
 5. ``generate_permit_list.json`` records the command, resolved options, correction statistics, and expected orientation.  Multi-barcode workflows additionally write ``sample_info.json``, ``sample_permit_map.bin``, and per-sample permit files for samples having retained cells.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -35,7 +35,10 @@ Finally, we quantify the collated rad file using the `cr-like` resolution strate
 
     $ alevin-fry quant -i <fry_odir> -m <tg_map> -t <num_threads> -r cr-like -o <fry_odir> 
 
-Note that with the exception of the `generate-permit-list` command, the other `alevin-fry` commands are designed to scale well with the number of provided threads. Thus, if you have multiple threads to use, then you can provide the appropriate argument to the `-t` option.
+The ``-t`` option controls the thread count used by each stage. Two threads is
+the practical minimum: a request of zero or one produces a prominent warning,
+is raised to two, and execution continues. Larger requests are honored, though
+the best scaling point depends on the stage and dataset.
 
 Detailed information on the alevin-fry commands
 -----------------------------------------------

--- a/src/collate.rs
+++ b/src/collate.rs
@@ -2502,3 +2502,25 @@ where
     Ok(())
 }
 */
+
+#[cfg(test)]
+mod tests {
+    use super::load_single_corrections;
+    use std::collections::HashMap;
+    use std::fs::File;
+
+    #[test]
+    fn single_barcode_loader_accepts_legacy_permit_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let expected = HashMap::from([(7_u64, 11_u64), (13_u64, 17_u64)]);
+        bincode::serialize_into(
+            File::create(dir.path().join("permit_map.bin")).unwrap(),
+            &expected,
+        )
+        .unwrap();
+
+        let log = slog::Logger::root(slog::Discard, slog::o!());
+        let loaded = load_single_corrections(dir.path(), 16, &log).unwrap();
+        assert_eq!(loaded, expected);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,7 @@ fn main() -> anyhow::Result<()> {
             arg!(--"sample-correction-mode" <SCMODE> "deprecated alias: exact, or 1-edit (Unique plus substitution-or-shift-1)")
                 .value_parser(["exact", "1-edit"])
                 .requires("sample-bc-list")
+                .hide(true)
         )
         .arg(
             arg!(--"cell-bc-correction" <STRATEGY> "cell-barcode collision policy: `unique` accepts one canonical target; `frequency` uses frozen exact counts and a confidence threshold")
@@ -281,12 +282,14 @@ fn main() -> anyhow::Result<()> {
     .arg(arg!(-c --compress "compress the output collated RAD file"))
     .arg(arg!(-m --"max-records" <MAXRECORDS> "deprecated approximate record-count memory control; use --memory-limit")
          .value_parser(value_parser!(u32))
-         .conflicts_with("memory-limit"))
+         .conflicts_with("memory-limit")
+         .hide(true))
     .arg(arg!(--"memory-limit" <SIZE> "collation buffer budget, excluding indexes and page cache (for example 2GiB or 4GB; default: 2GiB)")
          .value_parser(parse_memory_size)
          .conflicts_with("max-records"))
     .arg(arg!(--"collation-mode" <CMODE> "deprecated compatibility alias; all values select the optimized collator")
-         .value_parser(["two-round", "fast"]));
+         .value_parser(["two-round", "fast"])
+         .hide(true));
 
     let quant_app = Command::new("quant")
     .about("Quantify expression from a collated RAD file")

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -441,8 +441,9 @@ struct WorkerSharedState<R: MappedRecord> {
 /// Default threshold (in number of records) below which a cell uses the fast
 /// path that avoids HashMap-based equivalence class construction entirely.
 ///
-/// This is the default for `--small-thresh`, not a hard-coded limit; see
-/// [`QuantConfig::tiny_cell_thresh`]. The fast path implements `cr-like`
+/// This is the default for `--small-thresh`, not a hard-coded limit; the
+/// resolved value is carried by the worker configuration's
+/// `tiny_cell_thresh` field. The fast path implements `cr-like`
 /// winner-take-all semantics, so it is only taken when those semantics are
 /// what was asked for.
 pub const DEFAULT_SMALL_CELL_FAST_THRESHOLD: usize = 100;

--- a/tests/atac_integration.rs
+++ b/tests/atac_integration.rs
@@ -449,6 +449,39 @@ fn atac_sort_uses_compiled_plan_without_legacy_map() {
     );
 }
 
+#[test]
+fn atac_sort_uses_legacy_map_without_compiled_plan() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = make_test_logger();
+    let mix = CellMix {
+        good: 3,
+        unmapped: 0,
+        multimapped: 0,
+    };
+    let (rad_dir, gpl_dir) = stage_permit_list(tmp.path(), 4, &mix, &log);
+    std::fs::remove_file(gpl_dir.join("correction_plan.bin")).unwrap();
+
+    let sort_input = gpl_dir.clone();
+    let sort_rad = rad_dir.clone();
+    let sort_log = log.clone();
+    run_with_timeout("atac sort with legacy permit map", move || {
+        sort(
+            sort_input,
+            sort_rad,
+            2,
+            10_000,
+            false,
+            "atac_integration_test",
+            TEST_VERSION,
+            &sort_log,
+        )
+    });
+    assert!(
+        std::fs::metadata(gpl_dir.join("map.bed")).is_ok_and(|metadata| metadata.len() > 0),
+        "ATAC legacy fallback produced no BED output"
+    );
+}
+
 /// A cell whose records are *all* dropped by the scatter phase contributes no
 /// chunk, so the collated file legitimately holds fewer chunks than there are
 /// retained barcodes. That used to be a hard assertion failure.

--- a/tests/multi_barcode_integration.rs
+++ b/tests/multi_barcode_integration.rs
@@ -778,6 +778,10 @@ fn test_multi_bc_collate_and_quant_preserve_sample_cell_identity() {
     let total_cells = generate_permit_list(gpl_opts).unwrap();
     assert_eq!(total_cells, (num_samples * cells_per_sample) as u64);
 
+    // Older GPL outputs predate correction_plan.bin. Collation must retain
+    // its documented Hamming-1 Unique compatibility path for those outputs.
+    std::fs::remove_file(output_dir.join("correction_plan.bin")).unwrap();
+
     collate(
         output_dir.clone(),
         &rad_dir,


### PR DESCRIPTION
## Summary

- prepare alevin-fry 0.18.0 and replace the pinned Git dependency with published libradicl 0.18.0
- document deterministic correction, bounded collation, Flex spill/replay, ATAC integration, thread and memory floors, and the final hash/count optimizations
- hide retained deprecated aliases from normal help without changing their behavior
- enforce strict rustdoc in CI and repair the Sphinx and rustdoc findings
- add explicit single-RNA, multi-barcode, and ATAC legacy-artifact fallback coverage

## Validation

- 62 tests pass, 1 ignored (43 library, 2 CLI, 5 ATAC integration, 3 matrix-market integration, 9 multi-barcode integration)
- formatting, clippy with warnings denied, strict rustdoc, and strict Sphinx all pass
- sanitized `cargo publish --dry-run --locked --allow-dirty` packages and verifies against crates.io libradicl 0.18.0 with no Git dependency
- three full Flex v2 RC GPL/collate runs produced identical correction-plan and manifest hashes, 2,423,889 chunks, 1,869,082,132 written records, and 37,402,724,053-byte outputs
- fresh three-run current-master vs RC gate: GPL median 10.24 s vs 10.16 s; collation median 20.85 s vs 21.14 s; wall and RSS changes remain below the 3% release blocker

## Release order

libradicl 0.18.0 is already published and tagged. After this PR lands, publish this exact release through crates.io, tag v0.18.0, and wait for the registry/release artifact before completing simpleaf 0.28.0.
